### PR TITLE
This PR speeds up the initial delay in reading rush workspaces

### DIFF
--- a/change/workspace-tools-2020-05-25-11-09-37-faster.json
+++ b/change/workspace-tools-2020-05-25-11-09-37-faster.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "speeding up getRushWorkspaces by skipping the slow rush config reader by a simple json reader",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-25T18:09:37.831Z"
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "workspace-tools",
   "version": "0.7.4",
+  "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "license": "MIT",
   "scripts": {
     "build": "tsc",
     "change": "beachball change",
@@ -13,7 +13,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@microsoft/rush-lib": "^5.23.2",
     "@pnpm/lockfile-file": "^3.0.7",
     "@pnpm/logger": "^3.2.2",
     "@yarnpkg/lockfile": "^1.1.0",
@@ -22,6 +21,7 @@
     "fs-extra": "^9.0.0",
     "git-url-parse": "^11.1.2",
     "globby": "^11.0.0",
+    "jju": "^1.4.0",
     "matcher": "^3.0.0",
     "multimatch": "^4.0.0",
     "read-yaml-file": "^2.0.0"
@@ -30,6 +30,7 @@
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1",
     "@types/jest": "^25.2.2",
+    "@types/jju": "^1.4.1",
     "@types/matcher": "^2.0.0",
     "@types/multimatch": "^4.0.0",
     "@types/node": ">=12.0.0",

--- a/src/workspaces/getWorkspaces/rushWorkspaces.ts
+++ b/src/workspaces/getWorkspaces/rushWorkspaces.ts
@@ -1,6 +1,7 @@
 import findUp from "find-up";
 import path from "path";
-import { RushConfiguration } from "@microsoft/rush-lib";
+import jju from 'jju';
+import fs from 'fs';
 
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 
@@ -11,9 +12,7 @@ export function getRushWorkspaces(cwd: string): WorkspaceInfo {
       return [];
     }
 
-    const rushConfig = RushConfiguration.loadFromConfigurationFile(
-      rushJsonPath
-    );
+    const rushConfig = jju.parse(fs.readFileSync(rushJsonPath, 'utf-8'));
 
     return rushConfig.projects.map((project) => {
       return {

--- a/src/workspaces/getWorkspaces/rushWorkspaces.ts
+++ b/src/workspaces/getWorkspaces/rushWorkspaces.ts
@@ -1,7 +1,7 @@
 import findUp from "find-up";
 import path from "path";
-import jju from 'jju';
-import fs from 'fs';
+import jju from "jju";
+import fs from "fs";
 
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 
@@ -12,15 +12,20 @@ export function getRushWorkspaces(cwd: string): WorkspaceInfo {
       return [];
     }
 
-    const rushConfig = jju.parse(fs.readFileSync(rushJsonPath, 'utf-8'));
+    const rushConfig = jju.parse(fs.readFileSync(rushJsonPath, "utf-8"));
+    const root = path.dirname(rushJsonPath);
 
     return rushConfig.projects.map((project) => {
       return {
         name: project.packageName,
-        path: project.projectFolder,
+        path: path.join(root, project.projectFolder),
         packageJson: {
           ...project.packageJson,
-          packageJsonPath: path.join(project.projectFolder, "package.json"),
+          packageJsonPath: path.join(
+            root,
+            project.projectFolder,
+            "package.json"
+          ),
         },
       };
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/jju@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jju/-/jju-1.4.1.tgz#0a39f5f8e84fec46150a7b9ca985c3f89ad98e9f"
+  integrity sha512-LFt+YA7Lv2IZROMwokZKiPNORAV5N3huMs3IKnzlE430HWhWYZ8b+78HiwJXJJP1V2IEjinyJURuRJfGoaFSIA==
+
 "@types/matcher@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/matcher/-/matcher-2.0.0.tgz#da148a4ed4a545b6003b090891a8cb9237f37048"
@@ -2896,7 +2901,7 @@ jest@^25.0.0:
     import-local "^3.0.2"
     jest-cli "^25.5.4"
 
-jju@~1.4.0:
+jju@^1.4.0, jju@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=


### PR DESCRIPTION
If a repo is managed by rush, this getRushWorkspaces() function is doing the full configuration reading. All we need is a simple json reader to get the project folder information.