### PR TITLE
Transitive functions

### DIFF
--- a/change/workspace-tools-2020-06-19-10-50-45-transitive.json
+++ b/change/workspace-tools-2020-06-19-10-50-45-transitive.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding getTransitiveProviders and renamed getTransitiveDependencies to getTransitiveConsumers",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-19T17:50:45.141Z"
+}

--- a/src/__tests__/dependencies.test.ts
+++ b/src/__tests__/dependencies.test.ts
@@ -1,0 +1,116 @@
+import { PackageInfo } from "../types/PackageInfo";
+import {
+  getTransitiveConsumers,
+  getTransitiveProviders,
+} from "../dependencies";
+
+describe("getTransitiveConsumers", () => {
+  it("can get linear transitive consumers", () => {
+    const allPackages = {
+      a: stubPackage("a", ["b"]),
+      b: stubPackage("b", ["c"]),
+      c: stubPackage("c"),
+    };
+
+    const actual = getTransitiveConsumers(["c"], allPackages);
+
+    expect(actual).toContain("a");
+    expect(actual).toContain("b");
+  });
+
+  it("can get transitive consumer with deps", () => {
+    /*
+      [b, a]
+      [d, a]
+      [c, b]
+      [e, b]
+      [f, d]
+      [c, g]
+
+      expected: a, b, g (orignates from c)
+    */
+
+    const allPackages = {
+      a: stubPackage("a", ["b", "d"]),
+      b: stubPackage("b", ["c", "e"]),
+
+      c: stubPackage("c"),
+
+      d: stubPackage("d", ["f"]),
+      e: stubPackage("e"),
+      f: stubPackage("f"),
+      g: stubPackage("g", ["c"]),
+    };
+
+    const actual = getTransitiveConsumers(["c"], allPackages);
+
+    expect(actual).toContain("a");
+    expect(actual).toContain("b");
+    expect(actual).toContain("g");
+
+    expect(actual).not.toContain("d");
+    expect(actual).not.toContain("e");
+    expect(actual).not.toContain("f");
+    expect(actual).not.toContain("c");
+  });
+});
+
+describe("getTransitiveProviders", () => {
+  it("can get linear transitive providers", () => {
+    const allPackages = {
+      a: stubPackage("a", ["b"]),
+      b: stubPackage("b", ["c"]),
+      c: stubPackage("c"),
+    };
+
+    const actual = getTransitiveProviders(["a"], allPackages);
+
+    expect(actual).toContain("b");
+    expect(actual).toContain("c");
+  });
+
+  it("can get transitive providers with deps", () => {
+    /*
+      [b, a]
+      [c, b]
+      [e, c]
+      [f, c]
+      [f, e]
+      [g, f]
+
+      expected: e, f, g
+    */
+
+    const allPackages = {
+      a: stubPackage("a", ["b"]),
+      b: stubPackage("b", ["c"]),
+
+      c: stubPackage("c", ["e", "f"]),
+      d: stubPackage("d"),
+      e: stubPackage("e", ["f"]),
+      f: stubPackage("f", ["g"]),
+      g: stubPackage("g"),
+    };
+
+    const actual = getTransitiveProviders(["c"], allPackages);
+
+    expect(actual).toContain("e");
+    expect(actual).toContain("f");
+    expect(actual).toContain("g");
+
+    expect(actual).not.toContain("a");
+    expect(actual).not.toContain("b");
+    expect(actual).not.toContain("d");
+    expect(actual).not.toContain("c");
+  });
+});
+
+function stubPackage(name: string, deps: string[] = []) {
+  return {
+    name,
+    packageJsonPath: `packages/${name}`,
+    version: "1.0",
+    dependencies: deps.reduce((depMap, dep) => ({ ...depMap, [dep]: "*" }), {}),
+    devDependencies: {},
+  } as PackageInfo;
+}

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -36,7 +36,7 @@ export function getDependentMap(packages: PackageInfos) {
 }
 
 /**
- * for a package graph of a->b->c (where b depends on a), transitive consumers of a are all dependencies of b & c (or what are the consequences of a)
+ * for a package graph of a->b->c (where b depends on a), transitive consumers of a are b & c and their consumers (or what are the consequences of a)
  * @param targets
  * @param packages
  */
@@ -66,7 +66,7 @@ export function getTransitiveConsumers(
 }
 
 /**
- * for a package graph of a->b->c (where b depends on a), transitive providers of c are all dependencies of a & b (or what is needed to satisfy c)
+ * for a package graph of a->b->c (where b depends on a), transitive providers of c are a & b and their providers (or what is needed to satisfy c)
  * @param targets
  * @param packages
  */


### PR DESCRIPTION
There needs to be a mirror image of the getTransitiveDependencies(). The terminology was confusing so those are renamed to getTransitiveConsumers and getTransitiveProviders