### PR TITLE
Subgraph support for transitive consumers

### DIFF
--- a/change/workspace-tools-2020-08-19-15-35-44-subgraph.json
+++ b/change/workspace-tools-2020-08-19-15-35-44-subgraph.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding subgraph support get transitive consumer",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T22:35:44.331Z"
+}

--- a/src/__tests__/dependencies.test.ts
+++ b/src/__tests__/dependencies.test.ts
@@ -18,6 +18,28 @@ describe("getTransitiveConsumers", () => {
     expect(actual).toContain("b");
   });
 
+  it("can get linear transitive consumers with scope", () => {
+    const allPackages = {
+      grid: stubPackage("grid", ["foo"]),
+      word: stubPackage("word", ["bar"]),
+      foo: stubPackage("foo", ["core"]),
+      bar: stubPackage("bar", ["core"]),
+      core: stubPackage("core"),
+      demo: stubPackage("demo", ["grid", "word"]),
+    };
+
+    const actual = getTransitiveConsumers(["core"], allPackages, [
+      "grid",
+      "word",
+    ]);
+
+    expect(actual).toContain("foo");
+    expect(actual).toContain("bar");
+    expect(actual).toContain("grid");
+    expect(actual).toContain("word");
+    expect(actual).not.toContain("demo");
+  });
+
   it("can get transitive consumer with deps", () => {
     /*
       [b, a]
@@ -102,6 +124,39 @@ describe("getTransitiveProviders", () => {
     expect(actual).not.toContain("b");
     expect(actual).not.toContain("d");
     expect(actual).not.toContain("c");
+  });
+
+  it("can get transitive consumers with deps and scope", () => {
+    /*
+      [b, a]
+      [c, b]
+      [e, c]
+      [f, c]
+      [f, e]
+      [g, f]
+
+      expected: e, f, g
+    */
+
+    const allPackages = {
+      a: stubPackage("a", ["b", "h"]),
+      b: stubPackage("b", ["c"]),
+
+      c: stubPackage("c", ["e", "f"]),
+      d: stubPackage("d"),
+      e: stubPackage("e", ["f"]),
+      f: stubPackage("f", ["g"]),
+      g: stubPackage("g"),
+      h: stubPackage("h", ["i"]),
+      i: stubPackage("i", ["f"]),
+    };
+
+    const actual = getTransitiveConsumers(["f"], allPackages, ["b"]);
+
+    expect(actual).toContain("e");
+    expect(actual).toContain("c");
+    expect(actual).toContain("b");
+    expect(actual).not.toContain("h");
   });
 });
 

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,22 +1,44 @@
 import { PackageInfo, PackageInfos } from "./types/PackageInfo";
 
-const graphCache = new Map<PackageInfos, [string, string][]>();
+const graphCache = new Map<string, [string | null, string][]>();
 
-function getPackageGraph(packages: PackageInfos) {
-  if (graphCache.has(packages)) {
-    return graphCache.get(packages)!;
+function memoizedKey(packages: PackageInfos, scope: string[] = []) {
+  return JSON.stringify({ packages, scope });
+}
+
+function getPackageGraph(packages: PackageInfos, scope: string[] = []) {
+  const key = memoizedKey(packages, scope);
+
+  if (graphCache.has(key)) {
+    return graphCache.get(key)!;
   }
 
-  const edges: [string, string][] = [];
+  const edges: [string | null, string][] = [];
 
-  for (const [pkg, info] of Object.entries(packages)) {
+  const visited = new Set<string>();
+  const stack: string[] = scope.length > 0 ? [...scope] : Object.keys(packages);
+
+  while (stack.length > 0) {
+    const pkg = stack.pop()!;
+
+    if (visited.has(pkg)) {
+      continue;
+    }
+
+    visited.add(pkg);
+    const info = packages[pkg];
     const deps = getInternalDeps(info, packages);
-    for (const dep of deps) {
-      edges.push([dep, pkg]);
+    if (deps) {
+      for (const dep of deps) {
+        stack.push(dep);
+        edges.push([dep, pkg]);
+      }
+    } else {
+      edges.push([null, pkg]);
     }
   }
 
-  graphCache.set(packages, edges);
+  graphCache.set(key, edges);
 
   return edges;
 }
@@ -29,7 +51,9 @@ export function getDependentMap(packages: PackageInfos) {
       map.set(to, new Set());
     }
 
-    map.get(to)!.add(from);
+    if (from) {
+      map.get(to)!.add(from);
+    }
   }
 
   return map;
@@ -39,12 +63,14 @@ export function getDependentMap(packages: PackageInfos) {
  * for a package graph of a->b->c (where b depends on a), transitive consumers of a are b & c and their consumers (or what are the consequences of a)
  * @param targets
  * @param packages
+ * @param scope
  */
 export function getTransitiveConsumers(
   targets: string[],
-  packages: PackageInfos
+  packages: PackageInfos,
+  scope: string[] = []
 ) {
-  const graph = getPackageGraph(packages);
+  const graph = getPackageGraph(packages, scope);
   const pkgQueue: string[] = [...targets];
   const visited = new Set<string>();
 
@@ -85,7 +111,7 @@ export function getTransitiveProviders(
       visited.add(pkg);
 
       for (const [from, to] of graph) {
-        if (to === pkg) {
+        if (to === pkg && from) {
           pkgQueue.push(from);
         }
       }
@@ -95,8 +121,11 @@ export function getTransitiveProviders(
   return [...visited].filter((pkg) => !targets.includes(pkg));
 }
 
-/** @deprecated use `getDownstreamDependencies()` instead */
-export const getTransitiveDependencies = getTransitiveConsumers;
+// package dependencies = getting transitive providers
+export const getTransitiveDependencies = getTransitiveProviders;
+
+// package dependents = getting transitive consumers
+export const getTransitiveDependents = getTransitiveConsumers;
 
 export function getInternalDeps(info: PackageInfo, packages: PackageInfos) {
   const deps = Object.keys({ ...info.dependencies, ...info.devDependencies });


### PR DESCRIPTION
Sometimes, it is useful to find transitive consumers only within a subgraph. This allows to get that.