### PR TITLE
add extended-info to getPackageInfos

### DIFF
--- a/change/workspace-tools-2020-08-31-16-16-49-extended-info.json
+++ b/change/workspace-tools-2020-08-31-16-16-49-extended-info.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add extended-info to getPackageInfos",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-31T23:16:49.478Z"
+}

--- a/src/infoFromPackageJson.ts
+++ b/src/infoFromPackageJson.ts
@@ -20,14 +20,7 @@ export function infoFromPackageJson(
   packageJsonPath: string
 ): PackageInfo {
   return {
-    name: packageJson.name!,
-    version: packageJson.version,
     packageJsonPath,
-    dependencies: packageJson.dependencies,
-    devDependencies: packageJson.devDependencies,
-    peerDependencies: packageJson.peerDependencies,
-    private: packageJson.private !== undefined ? packageJson.private : false,
-    pipeline: packageJson.pipeline,
-    scripts: packageJson.scripts !== undefined ? packageJson.scripts : {},
+    ...packageJson,
   };
 }

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -7,8 +7,13 @@ export interface PackageInfo {
   peerDependencies?: { [dep: string]: string };
   private?: boolean;
   group?: string;
-  pipeline?: { [dep: string]: string[] };
   scripts?: { [dep: string]: string };
+  [key: string]:
+    | string
+    | boolean
+    | string[]
+    | { [dep: string]: string }
+    | undefined;
 }
 
 export interface PackageInfos {


### PR DESCRIPTION
Currently, getPackageInfo only grabs SOME info from packageJson. This adds the rest of the info to the package.json...