### PR TITLE
Support bundling of subsequent tools with yarn workspaces

### DIFF
--- a/change/workspace-tools-2020-09-10-16-33-58-yarn-bundle.json
+++ b/change/workspace-tools-2020-09-10-16-33-58-yarn-bundle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "do not do dynamic require",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T23:33:58.923Z"
+}

--- a/src/workspaces/getWorkspaces/yarnWorkspaces.ts
+++ b/src/workspaces/getWorkspaces/yarnWorkspaces.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import fs from "fs";
 import findWorkspaceRoot from "find-yarn-workspace-root";
 
 import { getPackagePaths } from "../../getPackagePaths";
@@ -25,13 +26,14 @@ function getYarnWorkspaceRoot(cwd: string): string {
 }
 
 function getRootPackageJson(yarnWorkspacesRoot: string) {
-  const packageJson = require(path.join(yarnWorkspacesRoot, "package.json"));
+  const packageJsonFile = path.join(yarnWorkspacesRoot, "package.json");
 
-  if (!packageJson) {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonFile, "utf-8"));
+    return packageJson;
+  } catch (e) {
     throw new Error("Could not load package.json from workspaces root");
   }
-
-  return packageJson;
 }
 
 function getPackages(packageJson: PackageJsonWorkspaces): string[] {


### PR DESCRIPTION
dynamic require on JSON files is a nono for bundlers.