### PR TITLE
Better scopes - match wildcards with and without package scopes

### DIFF
--- a/change/workspace-tools-2020-09-15-09-45-57-better-scopes.json
+++ b/change/workspace-tools-2020-09-15-09-45-57-better-scopes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "support scoped package matches to match regardless of scopes",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T16:45:57.715Z"
+}

--- a/src/__tests__/getScopedPackages.test.ts
+++ b/src/__tests__/getScopedPackages.test.ts
@@ -1,0 +1,62 @@
+import { getScopedPackages } from "../scope";
+import { PackageInfos } from "../types/PackageInfo";
+
+describe("getScopedPackages", () => {
+  it("can match scopes for full matches for an array", () => {
+    const results = getScopedPackages(["foo", "bar"], ["foo", "bar", "baz"]);
+    expect(results).toContain("foo");
+    expect(results).toContain("bar");
+    expect(results).not.toContain("baz");
+  });
+
+  it("can match scopes for full matches for a map", () => {
+    const results = getScopedPackages(["foo", "bar"], {
+      foo: {},
+      bar: {},
+      baz: {},
+    });
+    expect(results).toContain("foo");
+    expect(results).toContain("bar");
+    expect(results).not.toContain("baz");
+  });
+
+  it("can match scopes for full matches for a map of PackageInfos", () => {
+    const results = getScopedPackages(["foo", "bar"], {
+      foo: { name: "foo", packageJsonPath: "nowhere", version: "1.0.0" },
+      bar: { name: "bar", packageJsonPath: "nowhere", version: "1.0.0" },
+      baz: { name: "baz", packageJsonPath: "nowhere", version: "1.0.0" },
+    } as PackageInfos);
+    expect(results).toContain("foo");
+    expect(results).toContain("bar");
+    expect(results).not.toContain("baz");
+  });
+
+  it("can match with wildcards", () => {
+    const results = getScopedPackages(["foo*"], ["foo1", "foo2", "baz"]);
+    expect(results).toContain("foo1");
+    expect(results).toContain("foo2");
+    expect(results).not.toContain("baz");
+  });
+
+  it("can match with npm package scopes", () => {
+    const results = getScopedPackages(
+      ["foo"],
+      ["@yay/foo", "@yay1/foo", "foo", "baz"]
+    );
+    expect(results).toContain("@yay/foo");
+    expect(results).toContain("@yay1/foo");
+    expect(results).toContain("foo");
+    expect(results).not.toContain("baz");
+  });
+
+  it("can match with npm package scopes with wildcards", () => {
+    const results = getScopedPackages(
+      ["foo*"],
+      ["@yay/foo1", "@yay1/foo2", "foo", "baz"]
+    );
+    expect(results).toContain("@yay/foo1");
+    expect(results).toContain("@yay1/foo2");
+    expect(results).toContain("foo");
+    expect(results).not.toContain("baz");
+  });
+});

--- a/src/__tests__/getScopedPackages.test.ts
+++ b/src/__tests__/getScopedPackages.test.ts
@@ -59,4 +59,15 @@ describe("getScopedPackages", () => {
     expect(results).toContain("foo");
     expect(results).not.toContain("baz");
   });
+
+  it("uses the correct package scope when the search pattern starts a @ character", () => {
+    const results = getScopedPackages(
+      ["@yay/foo*"],
+      ["@yay/foo1", "@yay1/foo2", "foo", "baz"]
+    );
+    expect(results).toContain("@yay/foo1");
+    expect(results).not.toContain("@yay1/foo2");
+    expect(results).not.toContain("foo");
+    expect(results).not.toContain("baz");
+  });
 });

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,23 +1,36 @@
 import matcher from "matcher";
 
+/**
+ * Searches all package names based on "scoping" (i.e. "scope" in the sense of inclusion)
+ * NOTE: scoping is different than package scopes (@scope/package)
+ * @param searchScopes
+ * @param packages
+ */
 export function getScopedPackages(
-  scopes: string[],
+  searchScopes: string[],
   packages: { [pkg: string]: unknown } | string[]
 ) {
   const packageNames = Array.isArray(packages)
     ? packages
     : Object.keys(packages);
+
   const barePackageMap: { [key: string]: string[] } = {};
 
+  let inputs = packageNames;
+
   // Step 1: create a map of bare package name -> list of full package names
-  for (const pkg of packageNames) {
-    const bare = pkg.replace(/^@[^/]+\//, "");
-    barePackageMap[bare] = barePackageMap[bare] || [];
-    barePackageMap[bare].push(pkg);
+  // NOTE: do not perform barePackageMap lookup if any of the "scopes" arg starts with "@"
+  if (!searchScopes.find((scope) => scope.startsWith("@"))) {
+    for (const pkg of packageNames) {
+      const bare = pkg.replace(/^@[^/]+\//, "");
+      barePackageMap[bare] = barePackageMap[bare] || [];
+      barePackageMap[bare].push(pkg);
+    }
+    inputs = Object.keys(barePackageMap);
   }
 
   // Step 2: do the matcher algorithm (with support for wildcards like *)
-  const matched = matcher(Object.keys(barePackageMap), scopes);
+  const matched = matcher(inputs, searchScopes);
 
   // Step 3: reconstruct the list of full package names
   let results: string[] = [];

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -39,7 +39,7 @@ export function getScopedPackages(
     }
   }
 
-  return results;
+  return [...results];
 }
 
 function generateBarePackageMap(packageNames: string[]) {

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -14,16 +14,6 @@ export function getScopedPackages(
     ? packages
     : Object.keys(packages);
 
-  const barePackageMap: { [key: string]: string[] } = {};
-
-  // create a map of bare package name -> list of full package names
-  // NOTE: do not perform barePackageMap lookup if any of the "scopes" arg starts with "@"
-  for (const pkg of packageNames) {
-    const bare = pkg.replace(/^@[^/]+\//, "");
-    barePackageMap[bare] = barePackageMap[bare] || [];
-    barePackageMap[bare].push(pkg);
-  }
-
   const results = new Set<string>();
 
   // perform a package-scoped search (e.g. search is @scope/foo*)
@@ -38,6 +28,9 @@ export function getScopedPackages(
   // perform a package-unscoped search (e.g. search is foo*)
   const unscopedSearch = search.filter((needle) => !needle.startsWith("@"));
   if (unscopedSearch.length > 0) {
+    // only generate the bare package map if there ARE unscoped searches
+    const barePackageMap = generateBarePackageMap(packageNames);
+
     let matched = matcher(Object.keys(barePackageMap), unscopedSearch);
     for (const bare of matched) {
       for (const pkg of barePackageMap[bare]) {
@@ -47,4 +40,18 @@ export function getScopedPackages(
   }
 
   return results;
+}
+
+function generateBarePackageMap(packageNames: string[]) {
+  const barePackageMap: { [key: string]: string[] } = {};
+
+  // create a map of bare package name -> list of full package names
+  // NOTE: do not perform barePackageMap lookup if any of the "scopes" arg starts with "@"
+  for (const pkg of packageNames) {
+    const bare = pkg.replace(/^@[^/]+\//, "");
+    barePackageMap[bare] = barePackageMap[bare] || [];
+    barePackageMap[bare].push(pkg);
+  }
+
+  return barePackageMap;
 }

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -3,11 +3,11 @@ import matcher from "matcher";
 /**
  * Searches all package names based on "scoping" (i.e. "scope" in the sense of inclusion)
  * NOTE: scoping is different than package scopes (@scope/package)
- * @param searchScopes
+ * @param search
  * @param packages
  */
 export function getScopedPackages(
-  searchScopes: string[],
+  search: string[],
   packages: { [pkg: string]: unknown } | string[]
 ) {
   const packageNames = Array.isArray(packages)
@@ -16,26 +16,34 @@ export function getScopedPackages(
 
   const barePackageMap: { [key: string]: string[] } = {};
 
-  let inputs = packageNames;
-
-  // Step 1: create a map of bare package name -> list of full package names
+  // create a map of bare package name -> list of full package names
   // NOTE: do not perform barePackageMap lookup if any of the "scopes" arg starts with "@"
-  if (!searchScopes.find((scope) => scope.startsWith("@"))) {
-    for (const pkg of packageNames) {
-      const bare = pkg.replace(/^@[^/]+\//, "");
-      barePackageMap[bare] = barePackageMap[bare] || [];
-      barePackageMap[bare].push(pkg);
-    }
-    inputs = Object.keys(barePackageMap);
+  for (const pkg of packageNames) {
+    const bare = pkg.replace(/^@[^/]+\//, "");
+    barePackageMap[bare] = barePackageMap[bare] || [];
+    barePackageMap[bare].push(pkg);
   }
 
-  // Step 2: do the matcher algorithm (with support for wildcards like *)
-  const matched = matcher(inputs, searchScopes);
+  const results = new Set<string>();
 
-  // Step 3: reconstruct the list of full package names
-  let results: string[] = [];
-  for (const bare of matched) {
-    results = results.concat(barePackageMap[bare]);
+  // perform a package-scoped search (e.g. search is @scope/foo*)
+  const scopedSearch = search.filter((needle) => needle.startsWith("@"));
+  if (scopedSearch.length > 0) {
+    const matched = matcher(packageNames, scopedSearch);
+    for (const pkg of matched) {
+      results.add(pkg);
+    }
+  }
+
+  // perform a package-unscoped search (e.g. search is foo*)
+  const unscopedSearch = search.filter((needle) => !needle.startsWith("@"));
+  if (unscopedSearch.length > 0) {
+    let matched = matcher(Object.keys(barePackageMap), unscopedSearch);
+    for (const bare of matched) {
+      for (const pkg of barePackageMap[bare]) {
+        results.add(pkg);
+      }
+    }
   }
 
   return results;

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,6 +1,29 @@
-import { PackageInfos } from "./types/PackageInfo";
 import matcher from "matcher";
 
-export function getScopedPackages(scopes: string[], packages: PackageInfos) {
-  return matcher(Object.keys(packages), scopes);
+export function getScopedPackages(
+  scopes: string[],
+  packages: { [pkg: string]: unknown } | string[]
+) {
+  const packageNames = Array.isArray(packages)
+    ? packages
+    : Object.keys(packages);
+  const barePackageMap: { [key: string]: string[] } = {};
+
+  // Step 1: create a map of bare package name -> list of full package names
+  for (const pkg of packageNames) {
+    const bare = pkg.replace(/^@[^/]+\//, "");
+    barePackageMap[bare] = barePackageMap[bare] || [];
+    barePackageMap[bare].push(pkg);
+  }
+
+  // Step 2: do the matcher algorithm (with support for wildcards like *)
+  const matched = matcher(Object.keys(barePackageMap), scopes);
+
+  // Step 3: reconstruct the list of full package names
+  let results: string[] = [];
+  for (const bare of matched) {
+    results = results.concat(barePackageMap[bare]);
+  }
+
+  return results;
 }


### PR DESCRIPTION
Currently the `getScopedPackages()` only matches full names of the packages. If an entire repo's packages have npm scopes in them, it becomes really unwieldy.

So we now support:

matching foo*, @scope/foo* against ['foo', '@scope/foo'], etc.