### PR TITLE
Scope minimatch: support glob patterns instead of simple matcher

### DIFF
--- a/change/workspace-tools-2020-10-19-13-22-06-scope-minimatch.json
+++ b/change/workspace-tools-2020-10-19-13-22-06-scope-minimatch.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "replaced matcher with multimatch",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T20:22:06.181Z"
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "git-url-parse": "^11.1.2",
     "globby": "^11.0.0",
     "jju": "^1.4.0",
-    "matcher": "^3.0.0",
     "multimatch": "^4.0.0",
     "read-yaml-file": "^2.0.0"
   },
@@ -35,7 +34,6 @@
     "@types/glob": "^7.1.1",
     "@types/jest": "^25.2.2",
     "@types/jju": "^1.4.1",
-    "@types/matcher": "^2.0.0",
     "@types/multimatch": "^4.0.0",
     "@types/node": ">=12.0.0",
     "@types/yarnpkg__lockfile": "^1.1.3",

--- a/src/__tests__/getScopedPackages.test.ts
+++ b/src/__tests__/getScopedPackages.test.ts
@@ -70,4 +70,28 @@ describe("getScopedPackages", () => {
     expect(results).not.toContain("foo");
     expect(results).not.toContain("baz");
   });
+
+  it("can deal with brace expansion with scopes", () => {
+    const results = getScopedPackages(
+      ["@yay/foo{1,2}"],
+      ["@yay/foo1", "@yay/foo2", "@yay/foo3", "foo", "baz"]
+    );
+    expect(results).toContain("@yay/foo1");
+    expect(results).toContain("@yay/foo2");
+    expect(results).not.toContain("@yay/foo3");
+    expect(results).not.toContain("foo");
+    expect(results).not.toContain("baz");
+  });
+
+  it("can deal with negated search", () => {
+    const results = getScopedPackages(
+      ["@yay/foo*", "!@yay/foo3"],
+      ["@yay/foo1", "@yay/foo2", "@yay/foo3", "foo", "baz"]
+    );
+    expect(results).toContain("@yay/foo1");
+    expect(results).toContain("@yay/foo2");
+    expect(results).not.toContain("@yay/foo3");
+    expect(results).not.toContain("foo");
+    expect(results).not.toContain("baz");
+  });
 });

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,4 +1,4 @@
-import matcher from "matcher";
+import multimatch from "multimatch";
 
 /**
  * Searches all package names based on "scoping" (i.e. "scope" in the sense of inclusion)
@@ -17,21 +17,25 @@ export function getScopedPackages(
   const results = new Set<string>();
 
   // perform a package-scoped search (e.g. search is @scope/foo*)
-  const scopedSearch = search.filter((needle) => needle.startsWith("@"));
+  const scopedSearch = search.filter(
+    (needle) => needle.startsWith("@") || needle.startsWith("!@")
+  );
   if (scopedSearch.length > 0) {
-    const matched = matcher(packageNames, scopedSearch);
+    const matched = multimatch(packageNames, scopedSearch);
     for (const pkg of matched) {
       results.add(pkg);
     }
   }
 
   // perform a package-unscoped search (e.g. search is foo*)
-  const unscopedSearch = search.filter((needle) => !needle.startsWith("@"));
+  const unscopedSearch = search.filter(
+    (needle) => !needle.startsWith("@") && !needle.startsWith("!@")
+  );
   if (unscopedSearch.length > 0) {
     // only generate the bare package map if there ARE unscoped searches
     const barePackageMap = generateBarePackageMap(packageNames);
 
-    let matched = matcher(Object.keys(barePackageMap), unscopedSearch);
+    let matched = multimatch(Object.keys(barePackageMap), unscopedSearch);
     for (const bare of matched) {
       for (const pkg of barePackageMap[bare]) {
         results.add(pkg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,13 +627,6 @@
   resolved "https://registry.yarnpkg.com/@types/jju/-/jju-1.4.1.tgz#0a39f5f8e84fec46150a7b9ca985c3f89ad98e9f"
   integrity sha512-LFt+YA7Lv2IZROMwokZKiPNORAV5N3huMs3IKnzlE430HWhWYZ8b+78HiwJXJJP1V2IEjinyJURuRJfGoaFSIA==
 
-"@types/matcher@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/matcher/-/matcher-2.0.0.tgz#da148a4ed4a545b6003b090891a8cb9237f37048"
-  integrity sha512-M/JRIy0v7Ae9MBNii5HdV2kg+oRHy8SRQka5ZR1OEGI2GTzytUOw/prQrnr+0ULU772PqQg7IoddN07FJK725g==
-  dependencies:
-    matcher "*"
-
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1390,11 +1383,6 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.11.1:
   version "1.14.1"
@@ -2725,13 +2713,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-matcher@*, matcher@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
-  integrity sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==
-  dependencies:
-    escape-string-regexp "^4.0.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This adds support like this:

`foo{1,2}`