### PR TITLE
Allow a much bigger buffer size for workspace-tools' git operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ A collection of tools that are useful in a git-controlled monorepo that is manag
 - yarn workspaces
 - pnpm workspaces
 
+# Environment Variables
+
+## GIT_MAX_BUFFER: git operation maxBuffer
+
+Override this value with "GIT_MAX_BUFFER" environment variable. By default, it is using 500MB (as opposed to the
+default node.js maxBuffer of 1MB)
+
+## PREFERRED_WORKSPACE_MANAGER
+
+Sometimes multiple package manager files are checked in. It is necessary to hint to `workspace-tools` which manager
+is used: `yarn`, `pnpm`, `rush`
+
 # Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/change/workspace-tools-2020-11-30-10-16-34-git-buffer.json
+++ b/change/workspace-tools-2020-11-30-10-16-34-git-buffer.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Allow a much bigger buffer for getting changed packages",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-30T18:16:34.352Z"
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -17,6 +17,11 @@ const MaxBufferOption = process.env.GIT_MAX_BUFFER ? parseInt(process.env.GIT_MA
 export function git(args: string[], options?: { cwd: string, maxBuffer?: number }) {
   const results = spawnSync("git", args, { maxBuffer: MaxBufferOption, ...options });
 
+  // These errors are caused by the spawning itself
+  if (results.error) {
+    throw new Error(`git command failed: ${args.join(' ')}\n${results.error}`)
+  }
+
   if (results.status === 0) {
     return {
       stderr: results.stderr.toString().trimRight(),
@@ -127,7 +132,7 @@ export function getBranchChanges(branch: string, cwd: string) {
   });
 
   if (!results.success) {
-    throw new Error(`git command failed: ${diffCmd.join(' ')}`)
+    throw new Error(results.stderr)
   }
 
   let changes = results.stdout;


### PR DESCRIPTION
Defaults to 500MB now, will allow an override with an env variable called GIT_MAX_BUFFER