### PR TITLE
Add support for lerna monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of tools that are useful in a git-controlled monorepo that is manag
 - rush
 - yarn workspaces
 - pnpm workspaces
+- lerna
 
 # Environment Variables
 
@@ -16,7 +17,7 @@ default node.js maxBuffer of 1MB)
 ## PREFERRED_WORKSPACE_MANAGER
 
 Sometimes multiple package manager files are checked in. It is necessary to hint to `workspace-tools` which manager
-is used: `yarn`, `pnpm`, `rush`
+is used: `yarn`, `pnpm`, `rush`, or `lerna`
 
 # Contributing
 

--- a/src/__fixtures__/monorepo-lerna-npm/lerna.json
+++ b/src/__fixtures__/monorepo-lerna-npm/lerna.json
@@ -1,0 +1,6 @@
+{
+  "packages": [
+    "packages/*"
+  ],
+  "version": "0.0.0"
+}

--- a/src/__fixtures__/monorepo-lerna-npm/package-lock.json
+++ b/src/__fixtures__/monorepo-lerna-npm/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "monorepo-npm",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "workspaces": {
+        "packages": [
+          "packages/*"
+        ]
+      }
+    },
+    "node_modules/package-a": {
+      "resolved": "packages/package-a",
+      "link": true
+    },
+    "node_modules/package-b": {
+      "resolved": "packages/package-b",
+      "link": true
+    },
+    "packages/package-a": {
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "packages/package-b": {
+      "version": "0.1.0",
+      "license": "MIT"
+    }
+  },
+  "dependencies": {
+    "package-a": {
+      "version": "file:packages/package-a"
+    },
+    "package-b": {
+      "version": "file:packages/package-b"
+    }
+  }
+}

--- a/src/__fixtures__/monorepo-lerna-npm/package.json
+++ b/src/__fixtures__/monorepo-lerna-npm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "monorepo-lerna-npm",
+  "license": "MIT",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "lerna": "^3.22.1"
+  }
+}

--- a/src/__fixtures__/monorepo-lerna-npm/packages/package-a/node_modules/.bin/copy
+++ b/src/__fixtures__/monorepo-lerna-npm/packages/package-a/node_modules/.bin/copy
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs");
+
+const source = process.argv[2];
+const destination = process.argv[3];
+
+const sourceAbsolute = path.join(process.cwd(), source);
+const destinationAbsolute = path.join(process.cwd(), destination);
+const destinationAbsoluteDir = path.dirname(destinationAbsolute);
+
+if (!fs.existsSync(destinationAbsoluteDir)) {
+  fs.mkdirSync(destinationAbsoluteDir);
+}
+
+fs.copyFileSync(sourceAbsolute, destinationAbsolute);

--- a/src/__fixtures__/monorepo-lerna-npm/packages/package-a/package.json
+++ b/src/__fixtures__/monorepo-lerna-npm/packages/package-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-a",
+  "license": "MIT",
+  "version": "0.1.0",
+  "scripts": {
+    "compile": "node node_modules/.bin/copy src/index.ts lib/index.js",
+    "side-effect": "node node_modules/.bin/copy src/index.ts ../DONE"
+  }
+}

--- a/src/__fixtures__/monorepo-lerna-npm/packages/package-a/src/index.ts
+++ b/src/__fixtures__/monorepo-lerna-npm/packages/package-a/src/index.ts
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/src/__fixtures__/monorepo-lerna-npm/packages/package-b/node_modules/.bin/copy
+++ b/src/__fixtures__/monorepo-lerna-npm/packages/package-b/node_modules/.bin/copy
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs");
+
+const source = process.argv[2];
+const destination = process.argv[3];
+
+const sourceAbsolute = path.join(process.cwd(), source);
+const destinationAbsolute = path.join(process.cwd(), destination);
+const destinationAbsoluteDir = path.dirname(destinationAbsolute);
+
+if (!fs.existsSync(destinationAbsoluteDir)) {
+  fs.mkdirSync(destinationAbsoluteDir);
+}
+
+fs.copyFileSync(sourceAbsolute, destinationAbsolute);

--- a/src/__fixtures__/monorepo-lerna-npm/packages/package-b/package.json
+++ b/src/__fixtures__/monorepo-lerna-npm/packages/package-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-b",
+  "license": "MIT",
+  "version": "0.1.0",
+  "scripts": {
+    "compile": "node node_modules/.bin/copy src/index.ts lib/index.js"
+  }
+}

--- a/src/__fixtures__/monorepo-lerna-npm/packages/package-b/src/index.ts
+++ b/src/__fixtures__/monorepo-lerna-npm/packages/package-b/src/index.ts
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/src/__tests__/getWorkspaceRoot.test.ts
+++ b/src/__tests__/getWorkspaceRoot.test.ts
@@ -3,6 +3,7 @@ import { getYarnWorkspaceRoot } from "../workspaces/implementations/yarn";
 import { getPnpmWorkspaceRoot } from "../workspaces/implementations/pnpm";
 import { getRushWorkspaceRoot } from "../workspaces/implementations/rush";
 import { getNpmWorkspaceRoot } from "../workspaces/implementations/npm";
+import { getLernaWorkspaceRoot } from "../workspaces/implementations/lerna";
 
 describe("getYarnWorkspaceRoot()", () => {
   it("gets the root of the workspace", async () => {
@@ -35,6 +36,15 @@ describe("getNpmWorkspaceRoot()", () => {
   it("gets the root of the workspace", async () => {
     const repoRoot = await setupFixture("monorepo-npm");
     const workspaceRoot = getNpmWorkspaceRoot(repoRoot);
+
+    expect(workspaceRoot).toBe(repoRoot);
+  });
+});
+
+describe("getLernaWorkspaceRoot()", () => {
+  it("gets the root of the workspace", async () => {
+    const repoRoot = await setupFixture("monorepo-lerna-npm");
+    const workspaceRoot = getLernaWorkspaceRoot(repoRoot);
 
     expect(workspaceRoot).toBe(repoRoot);
   });

--- a/src/__tests__/getWorkspaces.test.ts
+++ b/src/__tests__/getWorkspaces.test.ts
@@ -67,21 +67,6 @@ describe("getRushWorkspaces()", () => {
   });
 });
 
-describe("getLernaWorkspaces()", () => {
-  it("gets the name and path of the workspaces", async () => {
-    const packageRoot = await setupFixture("monorepo-lerna-npm");
-    const workspacesPackageInfo = getLernaWorkspaces(packageRoot);
-
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
-
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-    ]);
-  });
-});
-
 describe("getNpmWorkspaces()", () => {
   it("gets the name and path of the workspaces", async () => {
     const packageRoot = await setupFixture("monorepo-npm");

--- a/src/__tests__/getWorkspaces.test.ts
+++ b/src/__tests__/getWorkspaces.test.ts
@@ -5,6 +5,7 @@ import { getYarnWorkspaces } from "../workspaces/implementations/yarn";
 import { getPnpmWorkspaces } from "../workspaces/implementations/pnpm";
 import { getRushWorkspaces } from "../workspaces/implementations/rush";
 import { getNpmWorkspaces } from "../workspaces/implementations/npm";
+import { getLernaWorkspaces } from "../workspaces/implementations/lerna";
 
 describe("getYarnWorkspaces()", () => {
   it("gets the name and path of the workspaces", async () => {
@@ -55,6 +56,21 @@ describe("getRushWorkspaces()", () => {
   it("gets the name and path of the workspaces", async () => {
     const packageRoot = await setupFixture("monorepo-rush-pnpm");
     const workspacesPackageInfo = getRushWorkspaces(packageRoot);
+
+    const packageAPath = path.join(packageRoot, "packages", "package-a");
+    const packageBPath = path.join(packageRoot, "packages", "package-b");
+
+    expect(workspacesPackageInfo).toMatchObject([
+      { name: "package-a", path: packageAPath },
+      { name: "package-b", path: packageBPath },
+    ]);
+  });
+});
+
+describe("getLernaWorkspaces()", () => {
+  it("gets the name and path of the workspaces", async () => {
+    const packageRoot = await setupFixture("monorepo-lerna-npm");
+    const workspacesPackageInfo = getLernaWorkspaces(packageRoot);
 
     const packageAPath = path.join(packageRoot, "packages", "package-a");
     const packageBPath = path.join(packageRoot, "packages", "package-b");

--- a/src/__tests__/getWorkspaces.test.ts
+++ b/src/__tests__/getWorkspaces.test.ts
@@ -101,4 +101,19 @@ describe("getWorkspaces", () => {
       ]);
     });
   });
+  
+  describe("lerna", () => {
+    it("gets the name and path of the workspaces", async () => {
+      const packageRoot = await setupFixture("monorepo-lerna-npm");
+      const workspacesPackageInfo = getLernaWorkspaces(packageRoot);
+
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
+
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+      ]);
+    });
+  });
 });

--- a/src/workspaces/WorkspaceManager.ts
+++ b/src/workspaces/WorkspaceManager.ts
@@ -1,1 +1,1 @@
-export type WorkspaceManager = "yarn" | "pnpm" | "rush" | "npm";
+export type WorkspaceManager = "yarn" | "pnpm" | "rush" | "npm" | "lerna";

--- a/src/workspaces/getWorkspaceRoot.ts
+++ b/src/workspaces/getWorkspaceRoot.ts
@@ -9,6 +9,7 @@ import { getRushWorkspaceRoot } from "./implementations/rush";
 
 import { WorkspaceManager } from "./WorkspaceManager";
 import { getNpmWorkspaceRoot } from "./implementations/npm";
+import { getLernaWorkspaceRoot } from "./implementations/lerna";
 
 const workspaceGetter: {
   [key in WorkspaceImplementations]: (cwd: string) => string;
@@ -17,6 +18,7 @@ const workspaceGetter: {
   pnpm: getPnpmWorkspaceRoot,
   rush: getRushWorkspaceRoot,
   npm: getNpmWorkspaceRoot,
+  lerna: getLernaWorkspaceRoot,
 };
 
 const preferred = process.env

--- a/src/workspaces/getWorkspaces.ts
+++ b/src/workspaces/getWorkspaces.ts
@@ -10,6 +10,7 @@ import { getRushWorkspaces } from "./implementations/rush";
 import { WorkspaceInfo } from "../types/WorkspaceInfo";
 import { WorkspaceManager } from "./WorkspaceManager";
 import { getNpmWorkspaces } from "./implementations/npm";
+import { getLernaWorkspaces } from "./implementations/lerna";
 
 const workspaceGetter: {
   [key in WorkspaceImplementations]: (cwd: string) => WorkspaceInfo;
@@ -18,6 +19,7 @@ const workspaceGetter: {
   pnpm: getPnpmWorkspaces,
   rush: getRushWorkspaces,
   npm: getNpmWorkspaces,
+  lerna: getLernaWorkspaces,
 };
 
 const preferred = process.env

--- a/src/workspaces/implementations/index.ts
+++ b/src/workspaces/implementations/index.ts
@@ -1,10 +1,17 @@
 import findUp from "find-up";
 
-export type WorkspaceImplementations = "yarn" | "pnpm" | "rush" | "npm";
+export type WorkspaceImplementations = "yarn" | "pnpm" | "rush" | "npm" | 'lerna';
 
 export function getWorkspaceImplementation(
   cwd: string
 ): WorkspaceImplementations | undefined {
+  // This needs to come before Yarn and NPM because
+  // lerna can be used with either package manager
+  const lernaJsonPath = findUp.sync("lerna.json", { cwd });
+  if (lernaJsonPath) {
+    return "lerna";
+  }
+  
   const yarnLockPath = findUp.sync("yarn.lock", { cwd });
   if (yarnLockPath) {
     return "yarn";

--- a/src/workspaces/implementations/lerna.ts
+++ b/src/workspaces/implementations/lerna.ts
@@ -1,0 +1,36 @@
+import findUp from "find-up";
+import fs from "fs";
+import jju from "jju";
+import path from "path";
+import { getPackagePaths } from "../../getPackagePaths";
+import { WorkspaceInfo } from "../../types/WorkspaceInfo";
+import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
+
+
+export function getLernaWorkspaceRoot(cwd: string): string {
+  const lernaJsonPath = findUp.sync("lerna.json", { cwd });
+
+  if (!lernaJsonPath) {
+    throw new Error("Could not find lerna workspace root");
+  }
+
+  return path.dirname(lernaJsonPath);
+}
+
+export function getLernaWorkspaces(cwd: string): WorkspaceInfo {
+  try {
+    const lernaWorkspaceRoot = getLernaWorkspaceRoot(cwd);
+    const lernaJsonPath = path.join(lernaWorkspaceRoot, "lerna.json");
+
+    const lernaConfig = jju.parse(fs.readFileSync(lernaJsonPath, "utf-8"));
+
+    const packagePaths = getPackagePaths(
+      lernaWorkspaceRoot,
+      lernaConfig.packages
+    );
+    const workspaceInfo = getWorkspacePackageInfo(packagePaths);
+    return workspaceInfo;
+  } catch {
+    return [];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,6 +578,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/git-url-parse@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/git-url-parse/-/git-url-parse-9.0.0.tgz#aac1315a44fa4ed5a52c3820f6c3c2fb79cbd12d"
+  integrity sha512-kA2RxBT/r/ZuDDKwMl+vFWn1Z0lfm1/Ik6Qb91wnSzyzCDa/fkM8gIOq6ruB7xfr37n6Mj5dyivileUVKsidlg==
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"


### PR DESCRIPTION
Add support for lerna monorepos regardless of whether actual npm/yarn workspaces are being used along with it.