### PR TITLE
Ensure tests clean up after themselves

### DIFF
--- a/change/workspace-tools-2021-02-26-20-22-51-ecraig-testCleanup.json
+++ b/change/workspace-tools-2021-02-26-20-22-51-ecraig-testCleanup.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Ensure tests clean up after themselves",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-02-27T04:22:51.983Z"
+}

--- a/package.json
+++ b/package.json
@@ -31,16 +31,18 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
+    "@types/git-url-parse": "^9.0.0",
     "@types/glob": "^7.1.1",
     "@types/jest": "^25.2.2",
     "@types/jju": "^1.4.1",
     "@types/multimatch": "^4.0.0",
     "@types/node": ">=12.0.0",
+    "@types/tmp": "^0.2.0",
     "@types/yarnpkg__lockfile": "^1.1.3",
     "beachball": "^1.31.0",
     "jest": "^25.0.0",
-    "tempy": "^0.5.0",
+    "tmp": "^0.2.1",
     "ts-jest": "^25.5.1",
-    "typescript": "^3.8.3"
+    "typescript": "3.8.3"
   }
 }

--- a/src/__tests__/getChangedPackages.test.ts
+++ b/src/__tests__/getChangedPackages.test.ts
@@ -1,14 +1,18 @@
 import path from "path";
 import fs from "fs";
 
-import { setupFixture } from "../helpers/setupFixture";
+import { cleanupFixtures, setupFixture } from "../helpers/setupFixture";
 import { stageAndCommit, git } from "../git";
 import { getChangedPackages } from "../workspaces/getChangedPackages";
 
 describe("getChangedPackages()", () => {
-  it("can detect changes inside an untracked file", async () => {
+  afterAll(() => {
+    cleanupFixtures();
+  });
+
+  it("can detect changes inside an untracked file", () => {
     // arrange
-    const root = await setupFixture("monorepo");
+    const root = setupFixture("monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
@@ -20,9 +24,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toContain("package-a");
   });
 
-  it("can detect changes inside an untracked file in a nested monorepo", async () => {
+  it("can detect changes inside an untracked file in a nested monorepo", () => {
     // arrange
-    const root = path.join(await setupFixture("monorepo-nested"), "monorepo");
+    const root = path.join(setupFixture("monorepo-nested"), "monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
@@ -34,9 +38,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toEqual(["package-a"]);
   });
 
-  it("can detect changes inside an unstaged file", async () => {
+  it("can detect changes inside an unstaged file", () => {
     // arrange
-    const root = await setupFixture("monorepo");
+    const root = setupFixture("monorepo");
 
     const newFile = path.join(root, "packages/package-a/src/index.ts");
     fs.writeFileSync(newFile, "hello foo test");
@@ -48,9 +52,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toContain("package-a");
   });
 
-  it("can detect changes inside an unstaged file in a nested monorepo", async () => {
+  it("can detect changes inside an unstaged file in a nested monorepo", () => {
     // arrange
-    const root = path.join(await setupFixture("monorepo-nested"), "monorepo");
+    const root = path.join(setupFixture("monorepo-nested"), "monorepo");
 
     const newFile = path.join(root, "packages/package-a/src/index.ts");
     fs.writeFileSync(newFile, "hello foo test");
@@ -62,9 +66,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toEqual(["package-a"]);
   });
 
-  it("can detect changes inside a staged file", async () => {
+  it("can detect changes inside a staged file", () => {
     // arrange
-    const root = await setupFixture("monorepo");
+    const root = setupFixture("monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
@@ -77,9 +81,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toContain("package-a");
   });
 
-  it("can detect changes inside a staged file in a nested monorepo", async () => {
+  it("can detect changes inside a staged file in a nested monorepo", () => {
     // arrange
-    const root = path.join(await setupFixture("monorepo-nested"), "monorepo");
+    const root = path.join(setupFixture("monorepo-nested"), "monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
@@ -92,9 +96,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toEqual(["package-a"]);
   });
 
-  it("can detect changes inside a file that has been committed in a different branch", async () => {
+  it("can detect changes inside a file that has been committed in a different branch", () => {
     // arrange
-    const root = await setupFixture("monorepo");
+    const root = setupFixture("monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
@@ -108,9 +112,9 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toContain("package-a");
   });
 
-  it("can detect changes inside a file that has been committed in a different branch in a nested monorepo", async () => {
+  it("can detect changes inside a file that has been committed in a different branch in a nested monorepo", () => {
     // arrange
-    const root = path.join(await setupFixture("monorepo-nested"), "monorepo");
+    const root = path.join(setupFixture("monorepo-nested"), "monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
@@ -124,18 +128,16 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toEqual(["package-a"]);
   });
 
-  it("can ignore glob patterns in detecting changes", async () => {
+  it("can ignore glob patterns in detecting changes", () => {
     // arrange
-    const root = await setupFixture("monorepo");
+    const root = setupFixture("monorepo");
 
     const newFile = path.join(root, "packages/package-a/footest.txt");
     fs.writeFileSync(newFile, "hello foo test");
     git(["add", newFile], { cwd: root });
 
     // act
-    const changedPkgs = getChangedPackages(root, "master", [
-      "packages/package-a/*",
-    ]);
+    const changedPkgs = getChangedPackages(root, "master", ["packages/package-a/*"]);
 
     // assert
     expect(changedPkgs).toEqual([]);

--- a/src/__tests__/getWorkspaceRoot.test.ts
+++ b/src/__tests__/getWorkspaceRoot.test.ts
@@ -1,39 +1,37 @@
-import { setupFixture } from "../helpers/setupFixture";
+import { cleanupFixtures, setupFixture } from "../helpers/setupFixture";
 import { getYarnWorkspaceRoot } from "../workspaces/implementations/yarn";
 import { getPnpmWorkspaceRoot } from "../workspaces/implementations/pnpm";
 import { getRushWorkspaceRoot } from "../workspaces/implementations/rush";
 import { getNpmWorkspaceRoot } from "../workspaces/implementations/npm";
 
-describe("getYarnWorkspaceRoot()", () => {
-  it("gets the root of the workspace", async () => {
-    const repoRoot = await setupFixture("monorepo");
+describe("getWorkspaceRoot", () => {
+  afterAll(() => {
+    cleanupFixtures();
+  });
+
+  it("handles yarn workspace", () => {
+    const repoRoot = setupFixture("monorepo");
     const workspaceRoot = getYarnWorkspaceRoot(repoRoot);
 
     expect(workspaceRoot).toBe(repoRoot);
   });
-});
 
-describe("getPnpmWorkspaceRoot()", () => {
-  it("gets the root of the workspace", async () => {
-    const repoRoot = await setupFixture("monorepo-pnpm");
+  it("handles pnpm workspace", () => {
+    const repoRoot = setupFixture("monorepo-pnpm");
     const workspaceRoot = getPnpmWorkspaceRoot(repoRoot);
 
     expect(workspaceRoot).toBe(repoRoot);
   });
-});
 
-describe("getRushWorkspaceRoot()", () => {
-  it("gets the root of the workspace", async () => {
-    const repoRoot = await setupFixture("monorepo-rush-pnpm");
+  it("handles rush workspace", () => {
+    const repoRoot = setupFixture("monorepo-rush-pnpm");
     const workspaceRoot = getRushWorkspaceRoot(repoRoot);
 
     expect(workspaceRoot).toBe(repoRoot);
   });
-});
 
-describe("getNpmWorkspaceRoot()", () => {
-  it("gets the root of the workspace", async () => {
-    const repoRoot = await setupFixture("monorepo-npm");
+  it("handles npm workspace", () => {
+    const repoRoot = setupFixture("monorepo-npm");
     const workspaceRoot = getNpmWorkspaceRoot(repoRoot);
 
     expect(workspaceRoot).toBe(repoRoot);

--- a/src/__tests__/getWorkspaces.test.ts
+++ b/src/__tests__/getWorkspaces.test.ts
@@ -1,97 +1,103 @@
 import path from "path";
 
-import { setupFixture } from "../helpers/setupFixture";
+import { cleanupFixtures, setupFixture } from "../helpers/setupFixture";
 import { getYarnWorkspaces } from "../workspaces/implementations/yarn";
 import { getPnpmWorkspaces } from "../workspaces/implementations/pnpm";
 import { getRushWorkspaces } from "../workspaces/implementations/rush";
 import { getNpmWorkspaces } from "../workspaces/implementations/npm";
 
-describe("getYarnWorkspaces()", () => {
-  it("gets the name and path of the workspaces", async () => {
-    const packageRoot = await setupFixture("monorepo");
-    const workspacesPackageInfo = getYarnWorkspaces(packageRoot);
-
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
-
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-    ]);
+describe("getWorkspaces", () => {
+  afterAll(() => {
+    cleanupFixtures();
   });
 
-  it("gets the name and path of the workspaces against a packages spec of an individual package", async () => {
-    const packageRoot = await setupFixture("monorepo-globby");
-    const workspacesPackageInfo = getYarnWorkspaces(packageRoot);
+  describe("yarn", () => {
+    it("gets the name and path of the workspaces", () => {
+      const packageRoot = setupFixture("monorepo");
+      const workspacesPackageInfo = getYarnWorkspaces(packageRoot);
 
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
-    const individualPath = path.join(packageRoot, "packages", "individual");
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
 
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "individual", path: individualPath },
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-    ]);
-  });
-});
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+      ]);
+    });
 
-describe("getPnpmWorkspaces()", () => {
-  it("gets the name and path of the workspaces", async () => {
-    const packageRoot = await setupFixture("monorepo-pnpm");
-    const workspacesPackageInfo = getPnpmWorkspaces(packageRoot);
+    it("gets the name and path of the workspaces against a packages spec of an individual package", () => {
+      const packageRoot = setupFixture("monorepo-globby");
+      const workspacesPackageInfo = getYarnWorkspaces(packageRoot);
 
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
+      const individualPath = path.join(packageRoot, "packages", "individual");
 
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-    ]);
-  });
-});
-
-describe("getRushWorkspaces()", () => {
-  it("gets the name and path of the workspaces", async () => {
-    const packageRoot = await setupFixture("monorepo-rush-pnpm");
-    const workspacesPackageInfo = getRushWorkspaces(packageRoot);
-
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
-
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-    ]);
-  });
-});
-
-describe("getNpmWorkspaces()", () => {
-  it("gets the name and path of the workspaces", async () => {
-    const packageRoot = await setupFixture("monorepo-npm");
-    const workspacesPackageInfo = getNpmWorkspaces(packageRoot);
-
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
-
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-    ]);
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "individual", path: individualPath },
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+      ]);
+    });
   });
 
-  it("gets the name and path of the workspaces using the shorthand configuration", async () => {
-    const packageRoot = await setupFixture("monorepo-shorthand");
-    const workspacesPackageInfo = getNpmWorkspaces(packageRoot);
+  describe("pnpm", () => {
+    it("gets the name and path of the workspaces", () => {
+      const packageRoot = setupFixture("monorepo-pnpm");
+      const workspacesPackageInfo = getPnpmWorkspaces(packageRoot);
 
-    const packageAPath = path.join(packageRoot, "packages", "package-a");
-    const packageBPath = path.join(packageRoot, "packages", "package-b");
-    const individualPath = path.join(packageRoot, "individual");
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
 
-    expect(workspacesPackageInfo).toMatchObject([
-      { name: "package-a", path: packageAPath },
-      { name: "package-b", path: packageBPath },
-      { name: "individual", path: individualPath },
-    ]);
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+      ]);
+    });
+  });
+
+  describe("rush", () => {
+    it("gets the name and path of the workspaces", () => {
+      const packageRoot = setupFixture("monorepo-rush-pnpm");
+      const workspacesPackageInfo = getRushWorkspaces(packageRoot);
+
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
+
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+      ]);
+    });
+  });
+
+  describe("npm", () => {
+    it("gets the name and path of the workspaces", () => {
+      const packageRoot = setupFixture("monorepo-npm");
+      const workspacesPackageInfo = getNpmWorkspaces(packageRoot);
+
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
+
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+      ]);
+    });
+
+    it("gets the name and path of the workspaces using the shorthand configuration", () => {
+      const packageRoot = setupFixture("monorepo-shorthand");
+      const workspacesPackageInfo = getNpmWorkspaces(packageRoot);
+
+      const packageAPath = path.join(packageRoot, "packages", "package-a");
+      const packageBPath = path.join(packageRoot, "packages", "package-b");
+      const individualPath = path.join(packageRoot, "individual");
+
+      expect(workspacesPackageInfo).toMatchObject([
+        { name: "package-a", path: packageAPath },
+        { name: "package-b", path: packageBPath },
+        { name: "individual", path: individualPath },
+      ]);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,6 +664,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/tmp@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
+  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -1228,11 +1233,6 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-random-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
-  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
 cssom@^0.4.1:
   version "0.4.4"
@@ -3724,21 +3724,6 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-temp-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
-  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
-
-tempy@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.5.0.tgz#2785c89df39fcc4d1714fc554813225e1581d70b"
-  integrity sha512-VEY96x7gbIRfsxqsafy2l5yVxxp3PhwAGoWMyC2D2Zt5DmEv+2tGiPOrquNRpf21hhGnKLVEsuqleqiZmKG/qw==
-  dependencies:
-    is-stream "^2.0.0"
-    temp-dir "^2.0.0"
-    type-fest "^0.12.0"
-    unique-string "^2.0.0"
-
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -3768,6 +3753,13 @@ through2@^2.0.2, through2@^2.0.3:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -3885,11 +3877,6 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-type-fest@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
-  integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
-
 type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
@@ -3907,7 +3894,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.3:
+typescript@3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
@@ -3921,13 +3908,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
-
-unique-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
-  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
-  dependencies:
-    crypto-random-string "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
While adding tests for another change (to come later), I noticed the tests weren't cleaning up after themselves. (The docs for [`tempy`](https://www.npmjs.com/package/tempy) don't mention anything about cleanup, so I assume it doesn't do any.) Although the temp directory may eventually get cleaned out automatically by the system, it's nice to manually clean up anyway.

To fix, switch to using `tmp`, which supposedly has automatic cleanup. And add a manual cleanup step for good measure since I haven't found automatic cleanup to be very reliable in the past.