### PR TITLE
Add support for more git commit command options

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -299,9 +299,9 @@ export function stage(patterns: string[], cwd: string) {
   }
 }
 
-export function commit(message: string, cwd: string) {
+export function commit(message: string, cwd: string, options:string[] = []) {
   try {
-    const commitResults = git(["commit", "-m", message], { cwd });
+    const commitResults = git(["commit", "-m", message, ...options], { cwd });
 
     if (!commitResults.success) {
       console.error("Cannot commit changes");

--- a/src/git.ts
+++ b/src/git.ts
@@ -313,9 +313,9 @@ export function commit(message: string, cwd: string, options:string[] = []) {
   }
 }
 
-export function stageAndCommit(patterns: string[], message: string, cwd: string) {
+export function stageAndCommit(patterns: string[], message: string, cwd: string, commitOptions:string[] = []) {
   stage(patterns, cwd);
-  commit(message, cwd);
+  commit(message, cwd, commitOptions);
 }
 
 export function revertLocalChanges(cwd: string) {


### PR DESCRIPTION
The commit function/utility  which is used in beachball currently accepts the message option ` git commit -m 'some message'` 
This change aims at allowing support for more [options](https://git-scm.com/docs/git-commit#_options) for the git commit command.

A sample scenario requiring this fix: The [beachball change](https://github.com/microsoft/beachball/blob/master/src/commands/change.ts) command in summary adds & commits change files for changed packages in a monorepo. 
In some cases, the staging area contains other files that are not  change-files. all staged files are including changed package source code are included in the commit. specifying what to commit using the `--only` option should solve this problem. ie : 
`commit('Change files', cwd, ["--only file1.js file2.txt"])`

This change will enable support for other options in the commit command.