### PR TITLE
Scope getRecentCommitMessages to HEAD

### DIFF
--- a/change/workspace-tools-2021-04-12-10-39-43-master.json
+++ b/change/workspace-tools-2021-04-12-10-39-43-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "feat: Only include HEAD commits in 'recent commits'",
+  "packageName": "workspace-tools",
+  "email": "asgramme@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-04-12T08:39:43.346Z"
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -179,7 +179,7 @@ export function getStagedChanges(cwd: string) {
 
 export function getRecentCommitMessages(branch: string, cwd: string) {
   try {
-    const results = git(["log", "--decorate", "--pretty=format:%s", branch, "HEAD"], { cwd });
+    const results = git(["log", "--decorate", "--pretty=format:%s", `${branch}..HEAD`], { cwd });
 
     if (!results.success) {
       return [];


### PR DESCRIPTION
Instead of including recent commits from the target branch, only look at
the commits that are _new_ in HEAD. This is usually what we want when
we're looking for messages describing what we have changed.