### PR TITLE
getting rid of console logs from the library

### DIFF
--- a/change/workspace-tools-f59b03f5-3539-4424-a296-938437109eda.json
+++ b/change/workspace-tools-f59b03f5-3539-4424-a296-938437109eda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "getting rid of console logs from the library",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/getDefaultRemote.test.ts
+++ b/src/__tests__/getDefaultRemote.test.ts
@@ -23,7 +23,6 @@ describe("getDefaultRemote()", () => {
     const cwd = setupFixture("basic");
     setupLocalRemote(cwd, "myRemote", "basic");
 
-    console.log(cwd);
     // act
     const remote = getDefaultRemote(cwd);
 

--- a/src/getPackageInfos.ts
+++ b/src/getPackageInfos.ts
@@ -10,19 +10,11 @@ export function getPackageInfos(cwd: string) {
   if (packageJsonFiles && packageJsonFiles.length > 0) {
     packageJsonFiles.forEach((packageJsonPath: string) => {
       try {
-        const packageJson = JSON.parse(
-          fs.readFileSync(packageJsonPath, "utf-8")
-        );
-        packageInfos[packageJson.name] = infoFromPackageJson(
-          packageJson,
-          packageJsonPath
-        );
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+        packageInfos[packageJson.name] = infoFromPackageJson(packageJson, packageJsonPath);
       } catch (e) {
         // Pass, the package.json is invalid
-        console.warn(
-          `Invalid package.json file detected ${packageJsonPath}: `,
-          e
-        );
+        throw new Error(`Invalid package.json file detected ${packageJsonPath}: ${e.message}`);
       }
     });
     return packageInfos;


### PR DESCRIPTION
There are a lot of "console spews" with code ported from another library about git