### PR TITLE
get the right default remote branch

### DIFF
--- a/change/workspace-tools-0987932f-122d-4ef2-9c1e-7dccf6d5a19d.json
+++ b/change/workspace-tools-0987932f-122d-4ef2-9c1e-7dccf6d5a19d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "get the right default remote branch",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -402,7 +402,26 @@ function normalizeRepoUrl(repositoryUrl: string) {
 
 export function getDefaultRemoteBranch(branch: string | undefined, cwd: string) {
   const defaultRemote = getDefaultRemote(cwd);
-  branch = branch || getDefaultBranch(cwd);
+
+  const showRemote = git(["remote", "show", defaultRemote], {cwd});
+
+  /**
+   * The `showRemote` returns something like this in stdout:
+   * 
+   * * remote origin
+   *   Fetch URL: ../monorepo-upstream/
+   *   Push  URL: ../monorepo-upstream/
+   *   HEAD branch: main
+   * 
+   */
+  const headBranchLine = showRemote.stdout.split(/\n/).find(line => line.includes('HEAD branch'));
+  let remoteDefaultBranch: string | undefined;
+
+  if (headBranchLine) {
+    remoteDefaultBranch = headBranchLine.replace(/^\s*HEAD branch:\s+/, '');
+  }
+
+  branch = branch || remoteDefaultBranch || getDefaultBranch(cwd);
 
   return `${defaultRemote}/${branch}`;
 }


### PR DESCRIPTION
uses git remote show origin method since init.defaultBranch isn't always set