### PR TITLE
Include optionalDependencies for pnpm-lock.yaml parsing

### DIFF
--- a/src/lockfile/nameAtVersion.ts
+++ b/src/lockfile/nameAtVersion.ts
@@ -1,3 +1,6 @@
 export function nameAtVersion(name: string, version: string): string {
+  if (!version) {
+    return name;
+  }
   return `${name}@${version}`;
 }

--- a/src/lockfile/nameAtVersion.ts
+++ b/src/lockfile/nameAtVersion.ts
@@ -1,6 +1,3 @@
 export function nameAtVersion(name: string, version: string): string {
-  if (!version) {
-    return name;
-  }
   return `${name}@${version}`;
 }

--- a/src/lockfile/parsePnpmLock.ts
+++ b/src/lockfile/parsePnpmLock.ts
@@ -16,6 +16,7 @@ export function parsePnpmLock(yaml: PnpmLockFile): ParsedLock {
       object[nameAtVersion(name, version)] = {
         version,
         dependencies: snapshot.dependencies,
+        optionalDependencies: snapshot.optionalDependencies,
       };
     }
   }

--- a/src/lockfile/types.ts
+++ b/src/lockfile/types.ts
@@ -3,6 +3,7 @@ export type Dependencies = { [key in string]: string };
 export type LockDependency = {
   version: string;
   dependencies?: Dependencies;
+  optionalDependencies?: Dependencies;
 };
 
 export type ParsedLock = {


### PR DESCRIPTION
I'm addressing two small issues:

1. Packages may specify "optionalDependencies". Currently the implementation for "parsePnpmLock" does not account for those. I've added optionalDependencies to the LockDependency type and pipe them through in parsePnpmLock
2. ~~In a rush repository, internal packages have their version field undefined in the pnpm-lock.yaml file. This is resulting in parsed lockfile entries reading as "foo@undefined". I think it's better form to not append "@undefined" and just use the name as the key. I've edited "nameAtVersion" to reflect this. However I see there's a larger work item to handle internal packages for rush repos. If it doesn't seem worth including this partial fix for handling .tgz files, I can remove it.~~ Removing this one.

Validation:

- built and linked locally to a project making use of "parseLockFile". Validated behaviors described above. 