### PR TITLE
Adds npm 7 package-lock.json parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A collection of tools that are useful in a git-controlled monorepo that is managed by one of these software:
 
+- lerna
+- npm workspaces
+- pnpm workspaces
 - rush
 - yarn workspaces
-- pnpm workspaces
-- lerna
 
 # Environment Variables
 
@@ -17,7 +18,7 @@ default node.js maxBuffer of 1MB)
 ## PREFERRED_WORKSPACE_MANAGER
 
 Sometimes multiple package manager files are checked in. It is necessary to hint to `workspace-tools` which manager
-is used: `yarn`, `pnpm`, `rush`, or `lerna`
+is used: `npm`, `yarn`, `pnpm`, `rush`, or `lerna`
 
 # Contributing
 

--- a/change/workspace-tools-3c48444d-9820-40a8-be86-fc4cca6f05f6.json
+++ b/change/workspace-tools-3c48444d-9820-40a8-be86-fc4cca6f05f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adds npm 7 package-lock.json parcer",
+  "packageName": "workspace-tools",
+  "email": "riacarmin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/workspace-tools-3c48444d-9820-40a8-be86-fc4cca6f05f6.json
+++ b/change/workspace-tools-3c48444d-9820-40a8-be86-fc4cca6f05f6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Adds npm 7 package-lock.json parcer",
+  "comment": "Implements NPM workspaces support to parseLockFile utility.",
   "packageName": "workspace-tools",
   "email": "riacarmin@microsoft.com",
   "dependentChangeType": "patch"

--- a/src/__fixtures__/monorepo-npm-unsupported/package-lock.json
+++ b/src/__fixtures__/monorepo-npm-unsupported/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "monorepo-npm",
+  "version": "0.1.0",
+  "lockfileVersion": 1
+}

--- a/src/__fixtures__/monorepo-npm-unsupported/package.json
+++ b/src/__fixtures__/monorepo-npm-unsupported/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "monorepo-npm",
+  "license": "MIT",
+  "version": "0.1.0",
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/src/__fixtures__/monorepo-npm-unsupported/packages/package-a/node_modules/.bin/copy
+++ b/src/__fixtures__/monorepo-npm-unsupported/packages/package-a/node_modules/.bin/copy
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs");
+
+const source = process.argv[2];
+const destination = process.argv[3];
+
+const sourceAbsolute = path.join(process.cwd(), source);
+const destinationAbsolute = path.join(process.cwd(), destination);
+const destinationAbsoluteDir = path.dirname(destinationAbsolute);
+
+if (!fs.existsSync(destinationAbsoluteDir)) {
+  fs.mkdirSync(destinationAbsoluteDir);
+}
+
+fs.copyFileSync(sourceAbsolute, destinationAbsolute);

--- a/src/__fixtures__/monorepo-npm-unsupported/packages/package-a/package.json
+++ b/src/__fixtures__/monorepo-npm-unsupported/packages/package-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-a",
+  "license": "MIT",
+  "version": "0.1.0",
+  "scripts": {
+    "compile": "node node_modules/.bin/copy src/index.ts lib/index.js",
+    "side-effect": "node node_modules/.bin/copy src/index.ts ../DONE"
+  }
+}

--- a/src/__fixtures__/monorepo-npm-unsupported/packages/package-a/src/index.ts
+++ b/src/__fixtures__/monorepo-npm-unsupported/packages/package-a/src/index.ts
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/src/__fixtures__/monorepo-npm-unsupported/packages/package-b/node_modules/.bin/copy
+++ b/src/__fixtures__/monorepo-npm-unsupported/packages/package-b/node_modules/.bin/copy
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs");
+
+const source = process.argv[2];
+const destination = process.argv[3];
+
+const sourceAbsolute = path.join(process.cwd(), source);
+const destinationAbsolute = path.join(process.cwd(), destination);
+const destinationAbsoluteDir = path.dirname(destinationAbsolute);
+
+if (!fs.existsSync(destinationAbsoluteDir)) {
+  fs.mkdirSync(destinationAbsoluteDir);
+}
+
+fs.copyFileSync(sourceAbsolute, destinationAbsolute);

--- a/src/__fixtures__/monorepo-npm-unsupported/packages/package-b/package.json
+++ b/src/__fixtures__/monorepo-npm-unsupported/packages/package-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-b",
+  "license": "MIT",
+  "version": "0.1.0",
+  "scripts": {
+    "compile": "node node_modules/.bin/copy src/index.ts lib/index.js"
+  }
+}

--- a/src/__fixtures__/monorepo-npm-unsupported/packages/package-b/src/index.ts
+++ b/src/__fixtures__/monorepo-npm-unsupported/packages/package-b/src/index.ts
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/src/__fixtures__/monorepo-npm/node_modules/.package-lock.json
+++ b/src/__fixtures__/monorepo-npm/node_modules/.package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "monorepo-npm",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/package-a": {
+      "resolved": "packages/package-a",
+      "link": true
+    },
+    "node_modules/package-b": {
+      "resolved": "packages/package-b",
+      "link": true
+    },
+    "packages/package-a": {
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "packages/package-b": {
+      "version": "0.1.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/src/__fixtures__/monorepo-npm/node_modules/package-a
+++ b/src/__fixtures__/monorepo-npm/node_modules/package-a
@@ -1,0 +1,1 @@
+../packages/package-a

--- a/src/__fixtures__/monorepo-npm/node_modules/package-b
+++ b/src/__fixtures__/monorepo-npm/node_modules/package-b
@@ -1,0 +1,1 @@
+../packages/package-b

--- a/src/__tests__/lockfile.test.ts
+++ b/src/__tests__/lockfile.test.ts
@@ -3,21 +3,24 @@ import { parseLockFile } from "../lockfile";
 
 const ERROR_MESSAGES = {
   NO_LOCK: "You do not have yarn.lock, pnpm-lock.yaml or package-lock.json. Please use one of these package managers.",
-  UNSUPPORTED: "Your package-lock.json version is not supported: 1. You need npm v7 or above and package-lock v2 or above. Please, upgrade npm or choose a different package manager.",
+  UNSUPPORTED:
+    "Your package-lock.json version is not supported: lockfileVersion is 1. You need npm version 7 or above and package-lock version 2 or above. Please, upgrade npm or choose a different package manager.",
 };
 
 describe("parseLockFile()", () => {
+  // General
+  it("throws if it cannot find lock file", async () => {
+    const packageRoot = await setupFixture("basic-without-lock-file");
+
+    await expect(parseLockFile(packageRoot)).rejects.toThrow(ERROR_MESSAGES.NO_LOCK);
+  });
+
+  // NPM
   it("parses package-lock.json file when it is found", async () => {
     const packageRoot = await setupFixture("monorepo-npm");
     const parsedLockeFile = await parseLockFile(packageRoot);
 
     expect(parsedLockeFile).toHaveProperty("type", "success");
-  });
-
-  it("throws if it cannot find a package-lock.json file", async () => {
-    const packageRoot = await setupFixture("basic-without-lock-file");
-
-    await expect(parseLockFile(packageRoot)).rejects.toThrow(ERROR_MESSAGES.NO_LOCK);
   });
 
   it("throws if npm version is unsupported", async () => {
@@ -26,10 +29,12 @@ describe("parseLockFile()", () => {
     await expect(parseLockFile(packageRoot)).rejects.toThrow(ERROR_MESSAGES.UNSUPPORTED);
   });
 
-  it("throws if it cannot find lock file", async () => {
-    const packageRoot = await setupFixture("basic-without-lock-file");
+  // Yarn
+  it("parses yarn.lock file when it is found", async () => {
+    const packageRoot = await setupFixture("basic");
+    const parsedLockeFile = await parseLockFile(packageRoot);
 
-    await expect(parseLockFile(packageRoot)).rejects.toThrow(ERROR_MESSAGES.NO_LOCK);
+    expect(parsedLockeFile).toHaveProperty("type", "success");
   });
 
   it("parses combined ranges in yarn.lock", async () => {
@@ -41,7 +46,8 @@ describe("parseLockFile()", () => {
     );
   });
 
-  it("parses pnpm-lock.yaml properly", async () => {
+  // PNPM
+  it("parses pnpm-lock.yaml file when it is found", async () => {
     const packageRoot = await setupFixture("basic-pnpm");
     const parsedLockeFile = await parseLockFile(packageRoot);
 

--- a/src/lockfile/index.ts
+++ b/src/lockfile/index.ts
@@ -61,7 +61,7 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
 
     if (!npmLock?.lockfileVersion || npmLock.lockfileVersion < 2) {
       throw new Error(
-        `Your package-lock.json version is not supported: ${npmLock.lockfileVersion}. You need npm v7 or above and package-lock v2 or above. Please, upgrade npm or choose a different package manager.`
+        `Your package-lock.json version is not supported: lockfileVersion is ${npmLock.lockfileVersion}. You need npm version 7 or above and package-lock version 2 or above. Please, upgrade npm or choose a different package manager.`
       );
     }
 

--- a/src/lockfile/index.ts
+++ b/src/lockfile/index.ts
@@ -54,7 +54,7 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
     const npmLock = JSON.parse(npmLockPath) as NpmLockFile;
 
     if (!npmLock.lockfileVersion || npmLock.lockfileVersion < 2) {
-      throw new Error(`Your package-lock.json version is not supported: ${npmLock.lockfileVersion}. You need npm v7 or above and package-lock v2 or above. Please, upgrade or choose a different package manager.`);
+      throw new Error(`Your package-lock.json version is not supported: ${npmLock.lockfileVersion}. You need npm v7 or above and package-lock v2 or above. Please, upgrade npm or choose a different package manager.`);
     }
   
     memoization[npmLockPath] = parseNpmLock(npmLock);

--- a/src/lockfile/index.ts
+++ b/src/lockfile/index.ts
@@ -2,7 +2,7 @@
 import path from "path";
 import findUp from "find-up";
 import fs from "fs-extra";
-import { ParsedLock, PnpmLockFile } from "./types";
+import { ParsedLock, PnpmLockFile, NpmLockFile } from "./types";
 import readYamlFile from "read-yaml-file";
 import { nameAtVersion } from "./nameAtVersion";
 import { parsePnpmLock } from "./parsePnpmLock";
@@ -51,10 +51,10 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
       return memoization[npmLockPath];
     }
 
-    const npmLock = JSON.parse(npmLockPath)
+    const npmLock = JSON.parse(npmLockPath) as NpmLockFile;
 
-    if (npmLock.version < 2) {
-      throw new Error(`Your package-lock.json version is not supported: ${npmLock.version}. You need npm v7 or above and package-lock v2 or above. Please, upgrade or choose a different package manager.`);
+    if (!npmLock.lockfileVersion || npmLock.lockfileVersion < 2) {
+      throw new Error(`Your package-lock.json version is not supported: ${npmLock.lockfileVersion}. You need npm v7 or above and package-lock v2 or above. Please, upgrade or choose a different package manager.`);
     }
   
     memoization[npmLockPath] = parseNpmLock(npmLock);

--- a/src/lockfile/parseNpmLock.ts
+++ b/src/lockfile/parseNpmLock.ts
@@ -1,0 +1,6 @@
+import { ParsedLock, NpmLockFile } from "./types";
+
+export const parseNpmLock = (lock: NpmLockFile): ParsedLock => ({
+  object: lock.dependendcies ?? {},
+  type: "success",
+});

--- a/src/lockfile/parseNpmLock.ts
+++ b/src/lockfile/parseNpmLock.ts
@@ -1,6 +1,6 @@
 import { ParsedLock, NpmLockFile } from "./types";
 
 export const parseNpmLock = (lock: NpmLockFile): ParsedLock => ({
-  object: lock.dependendcies ?? {},
+  object: lock.dependencies ?? {},
   type: "success",
 });

--- a/src/lockfile/types.ts
+++ b/src/lockfile/types.ts
@@ -16,28 +16,28 @@ export interface PnpmLockFile {
   packages: { [name: string]: any };
 }
 
-export interface NpmWorspacesInfo {
-  version: "string";
-  workspaces: Record<"packages", string[]>;
+export interface NpmWorkspacesInfo {
+  version: string;
+  workspaces: { packages: string[] };
 }
 
-export interface NpmSynlinkInfo {
-  resolved: string; // Where the package is  reslved from.
+export interface NpmSymlinkInfo {
+  resolved: string; // Where the package is  resolved from.
   link: boolean; // A flag to indicate that this is a symbolic link.
-  integrity?: 'sha512' | 'sha1';
+  integrity?: "sha512" | "sha1";
   dev?: boolean;
   optional?: boolean;
   devOptional?: boolean;
-  dependendcies?: { [key in string]: LockDependency; }
+  dependencies?: { [key: string]: LockDependency };
 }
 
 export interface NpmLockFile {
   name: string;
   version: string;
-  lockfileVersion?: number; // 1: v5, v6; 2: backwards compatible v7; 3: non-backwards compatible v7 
+  lockfileVersion?: 1 | 2 | 3; // 1: v5, v6; 2: backwards compatible v7; 3: non-backwards compatible v7
   requires?: boolean;
   packages?: {
-    ""?: NpmWorspacesInfo, // Monorepo root
-  } & Record<string, NpmSynlinkInfo | LockDependency>;
-  dependendcies?: { [key in string]: LockDependency; }
+    ""?: NpmWorkspacesInfo; // Monorepo root
+  } & { [key: string]: NpmSymlinkInfo | LockDependency };
+  dependencies?: { [key: string]: LockDependency };
 }

--- a/src/lockfile/types.ts
+++ b/src/lockfile/types.ts
@@ -15,3 +15,29 @@ export type ParsedLock = {
 export interface PnpmLockFile {
   packages: { [name: string]: any };
 }
+
+export interface NpmWorspacesInfo {
+  version: "string";
+  workspaces: Record<"packages", string[]>;
+}
+
+export interface NpmSynlinkInfo {
+  resolved: string; // Where the package is  reslved from.
+  link: boolean; // A flag to indicate that this is a symbolic link.
+  integrity?: 'sha512' | 'sha1';
+  dev?: boolean;
+  optional?: boolean;
+  devOptional?: boolean;
+  dependendcies?: { [key in string]: LockDependency; }
+}
+
+export interface NpmLockFile {
+  name: string;
+  version: string;
+  lockfileVersion?: number; // 1: v5, v6; 2: backwards compatible v7; 3: non-backwards compatible v7 
+  requires?: boolean;
+  packages?: {
+    ""?: NpmWorspacesInfo, // Monorepo root
+  } & Record<string, NpmSynlinkInfo | LockDependency>;
+  dependendcies?: { [key in string]: LockDependency; }
+}

--- a/src/workspaces/getWorkspaces.ts
+++ b/src/workspaces/getWorkspaces.ts
@@ -3,14 +3,14 @@ import {
   WorkspaceImplementations,
 } from "./implementations";
 
+import { getLernaWorkspaces } from "./implementations/lerna";
+import { getNpmWorkspaces } from "./implementations/npm";
 import { getPnpmWorkspaces } from "./implementations/pnpm";
-import { getYarnWorkspaces } from "./implementations/yarn";
 import { getRushWorkspaces } from "./implementations/rush";
+import { getYarnWorkspaces } from "./implementations/yarn";
 
 import { WorkspaceInfo } from "../types/WorkspaceInfo";
 import { WorkspaceManager } from "./WorkspaceManager";
-import { getNpmWorkspaces } from "./implementations/npm";
-import { getLernaWorkspaces } from "./implementations/lerna";
 
 const workspaceGetter: {
   [key in WorkspaceImplementations]: (cwd: string) => WorkspaceInfo;

--- a/src/workspaces/implementations/npm.ts
+++ b/src/workspaces/implementations/npm.ts
@@ -12,6 +12,6 @@ export function getNpmWorkspaceRoot(cwd: string): string {
 }
 
 export function getNpmWorkspaces(cwd: string): WorkspaceInfo {
-  const yarnWorkspacesRoot = getNpmWorkspaceRoot(cwd);
-  return getWorkspaceInfoFromWorkspaceRoot(yarnWorkspacesRoot);
+  const npmWorkspacesRoot = getNpmWorkspaceRoot(cwd);
+  return getWorkspaceInfoFromWorkspaceRoot(npmWorkspacesRoot);
 }


### PR DESCRIPTION
# Description
npm introduced workspaces in version 7, similar to the feature in Yarn. We want to add a parser for `package-lock.json` version 2 and above to enable support.

# To-Do
- [x] Adds tests