### PR TITLE
Fix git fetch - addresses a potential security concern regarding git fetch

### DIFF
--- a/change/workspace-tools-01b53966-7f59-4ab9-abd7-ac355a7ae3b1.json
+++ b/change/workspace-tools-01b53966-7f59-4ab9-abd7-ac355a7ae3b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes a potential security issue where fetch --upload-pack can allow for command injection",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -118,7 +118,7 @@ export function getUntrackedChanges(cwd: string) {
 }
 
 export function fetchRemote(remote: string, cwd: string) {
-  const results = git(["fetch", remote], { cwd });
+  const results = git(["fetch", "--", remote], { cwd });
 
   if (!results.success) {
     throw gitError(`Cannot fetch remote: ${remote}`);
@@ -126,7 +126,7 @@ export function fetchRemote(remote: string, cwd: string) {
 }
 
 export function fetchRemoteBranch(remote: string, remoteBranch: string, cwd: string) {
-  const results = git(["fetch", remote, remoteBranch], { cwd });
+  const results = git(["fetch", "--", remote, remoteBranch], { cwd });
 
   if (!results.success) {
     throw gitError(`Cannot fetch remote: ${remote} ${remoteBranch}`);


### PR DESCRIPTION
fixes #102 

adds a "--" to git fetch so no extra git args can be passed in place of remote & remotebranch 