### PR TITLE
Changed packages between 2 refs

### DIFF
--- a/change/workspace-tools-29afcc3f-5b1b-4b05-b76f-d1ea3ed394af.json
+++ b/change/workspace-tools-29afcc3f-5b1b-4b05-b76f-d1ea3ed394af.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds a new API to allow retrieving a list of packages affected by files and also by git ref range",
+  "packageName": "workspace-tools",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/__tests__/getChangedPackages.test.ts
+++ b/src/__tests__/getChangedPackages.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 
 import { cleanupFixtures, setupFixture, setupLocalRemote } from "../helpers/setupFixture";
 import { stageAndCommit, git } from "../git";
-import { getChangedPackages } from "../workspaces/getChangedPackages";
+import { getChangedPackages, getChangedPackagesBetweenRefs } from "../workspaces/getChangedPackages";
 
 describe("getChangedPackages()", () => {
   afterAll(() => {
@@ -158,5 +158,27 @@ describe("getChangedPackages()", () => {
 
     // assert
     expect(changedPkgs).toEqual([]);
+  });
+
+  it.only("can detect changed packages between two refs", () => {
+    // arrange
+    const root = setupFixture("monorepo");
+
+    const newFile = path.join(root, "packages/package-a/footest.txt");
+    fs.writeFileSync(newFile, "hello foo test");
+    git(["add", newFile], { cwd: root });
+    stageAndCommit(["packages/package-a/footest.txt"], "test commit in a", root);
+
+    const newFile2 = path.join(root, "packages/package-b/footest2.txt");
+    fs.writeFileSync(newFile2, "hello foo test");
+    git(["add", newFile2], { cwd: root });
+    stageAndCommit(["packages/package-b/footest2.txt"], "test commit in b", root);
+
+    // act
+    const changedPkgs = getChangedPackagesBetweenRefs(root, "HEAD^1", "HEAD");
+
+    // assert
+    expect(changedPkgs).toContain("package-b");
+    expect(changedPkgs).not.toContain("package-a");
   });
 });

--- a/src/__tests__/getChangedPackages.test.ts
+++ b/src/__tests__/getChangedPackages.test.ts
@@ -7,7 +7,7 @@ import { getChangedPackages } from "../workspaces/getChangedPackages";
 
 describe("getChangedPackages()", () => {
   afterAll(() => {
-    cleanupFixtures();
+    //cleanupFixtures();
   });
 
   it("can detect changes inside an untracked file", () => {
@@ -96,7 +96,7 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toEqual(["package-a"]);
   });
 
-  it("can detect changes inside a file that has been committed in a different branch", () => {
+  it.only("can detect changes inside a file that has been committed in a different branch", () => {
     // arrange
     const root = setupFixture("monorepo");
 

--- a/src/__tests__/getChangedPackages.test.ts
+++ b/src/__tests__/getChangedPackages.test.ts
@@ -7,7 +7,7 @@ import { getChangedPackages } from "../workspaces/getChangedPackages";
 
 describe("getChangedPackages()", () => {
   afterAll(() => {
-    //cleanupFixtures();
+    cleanupFixtures();
   });
 
   it("can detect changes inside an untracked file", () => {
@@ -96,7 +96,7 @@ describe("getChangedPackages()", () => {
     expect(changedPkgs).toEqual(["package-a"]);
   });
 
-  it.only("can detect changes inside a file that has been committed in a different branch", () => {
+  it("can detect changes inside a file that has been committed in a different branch", () => {
     // arrange
     const root = setupFixture("monorepo");
 

--- a/src/__tests__/getPackagesByFiles.test.ts
+++ b/src/__tests__/getPackagesByFiles.test.ts
@@ -23,4 +23,44 @@ describe("getChangedPackages()", () => {
     expect(packages).toContain("package-a");
     expect(packages).not.toContain("package-b");
   });
+
+  it("can find can ignore changes in a glob pattern", () => {
+    // arrange
+    const root = setupFixture("monorepo");
+
+    const newFileA = path.join(root, "packages/package-a/footest.txt");
+    fs.writeFileSync(newFileA, "hello foo test");
+
+    const newFileB = path.join(root, "packages/package-b/footest.txt");
+    fs.writeFileSync(newFileB, "hello foo test");
+
+    // act
+    const packages = getPackagesByFiles(root, ["packages/package-a/footest.txt", "packages/package-b/footest.txt"], ["packages/package-b/**"]);
+
+    // assert
+    expect(packages).toContain("package-a");
+    expect(packages).not.toContain("package-b");
+  });
+
+  it("can find can handle empty files", () => {
+    // arrange
+    const root = setupFixture("monorepo");
+
+    // act
+    const packages = getPackagesByFiles(root, []);
+
+    // assert
+    expect(packages.length).toBe(0);
+  });
+
+  it("can find can handle unrelated files", () => {
+    // arrange
+    const root = setupFixture("monorepo");
+
+    // act
+    const packages = getPackagesByFiles(root, ["package.json"]);
+
+    // assert
+    expect(packages.length).toBe(0);
+  });
 });

--- a/src/__tests__/getPackagesByFiles.test.ts
+++ b/src/__tests__/getPackagesByFiles.test.ts
@@ -1,0 +1,26 @@
+import path from "path";
+import fs from "fs";
+
+import { cleanupFixtures, setupFixture, setupLocalRemote } from "../helpers/setupFixture";
+import { getPackagesByFiles } from "../workspaces/getPackagesByFiles";
+
+describe("getChangedPackages()", () => {
+  afterAll(() => {
+    cleanupFixtures();
+  });
+
+  it("can find all packages that contain the files in a monorepo", () => {
+    // arrange
+    const root = setupFixture("monorepo");
+
+    const newFile = path.join(root, "packages/package-a/footest.txt");
+    fs.writeFileSync(newFile, "hello foo test");
+
+    // act
+    const packages = getPackagesByFiles(root, ["packages/package-a/footest.txt"]);
+
+    // assert
+    expect(packages).toContain("package-a");
+    expect(packages).not.toContain("package-b");
+  });
+});

--- a/src/git.ts
+++ b/src/git.ts
@@ -159,20 +159,13 @@ export function getChanges(branch: string, cwd: string) {
  * @param cwd
  */
 export function getBranchChanges(branch: string, cwd: string) {
-  try {
-    return processGitOutput(git(["--no-pager", "diff", "--name-only", "--relative", branch + "..."], { cwd }));
-  } catch (e) {
-    throw gitError(`Cannot gather information about branch changes`, e);
-  }
+  return getChangesBetweenRefs(branch, "", [], "", cwd)
 }
 
 export function getChangesBetweenRefs(fromRef: string, toRef: string, options: string[], pattern: string, cwd: string) {
   try {
-    console.log(["git", "--no-pager", "diff", "--relative", "--name-only", ...options, `${fromRef}...${toRef}`, "--", pattern].join(' '), cwd)
-    console.log(["--no-pager", "diff", "--name-only", "--relative", fromRef + "..."].join(' '), cwd)
-
     return processGitOutput(
-      git(["--no-pager", "diff", "--relative", "--name-only", ...options, `${fromRef}...${toRef}`, "--", pattern], {
+      git(["--no-pager", "diff", "--name-only", "--relative", ...options, `${fromRef}...${toRef}`, ...(pattern ? ["--", pattern]: [])], {
         cwd,
       })
     );

--- a/src/git.ts
+++ b/src/git.ts
@@ -168,6 +168,9 @@ export function getBranchChanges(branch: string, cwd: string) {
 
 export function getChangesBetweenRefs(fromRef: string, toRef: string, options: string[], pattern: string, cwd: string) {
   try {
+    console.log(["git", "--no-pager", "diff", "--relative", "--name-only", ...options, `${fromRef}...${toRef}`, "--", pattern].join(' '), cwd)
+    console.log(["--no-pager", "diff", "--name-only", "--relative", fromRef + "..."].join(' '), cwd)
+
     return processGitOutput(
       git(["--no-pager", "diff", "--relative", "--name-only", ...options, `${fromRef}...${toRef}`, "--", pattern], {
         cwd,

--- a/src/workspaces/getChangedPackages.ts
+++ b/src/workspaces/getChangedPackages.ts
@@ -7,9 +7,18 @@ import {
   getUntrackedChanges,
 } from "../git";
 import { getWorkspaces } from "./getWorkspaces";
-import multimatch from "multimatch";
-import path from "path";
 import { getPackagesByFiles } from "./getPackagesByFiles";
+
+function getChangedPackagesByFiles(cwd: string, files: string[], ignoreGlobs: string[] = []) {
+  const workspaceInfo = getWorkspaces(cwd);
+  
+  const packages = getPackagesByFiles(cwd, files, ignoreGlobs, workspaceInfo);
+  if (packages.length > 0) {
+    return packages;
+  } 
+
+  return workspaceInfo.map((pkg) => pkg.name);
+}
 
 /**
  * Finds all packages that had been changed between two refs in the repo under cwd
@@ -43,7 +52,7 @@ export function getChangedPackagesBetweenRefs(
     ]),
   ];
 
-  return getPackagesByFiles(cwd, changes, ignoreGlobs);
+  return getChangedPackagesByFiles(cwd, changes, ignoreGlobs);
 }
 
 /**
@@ -74,6 +83,6 @@ export function getChangedPackages(cwd: string, target: string | undefined, igno
     ]),
   ];
   
-  return getPackagesByFiles(cwd, changes, ignoreGlobs);
+  return getChangedPackagesByFiles(cwd, changes, ignoreGlobs);
 }
 

--- a/src/workspaces/getChangedPackages.ts
+++ b/src/workspaces/getChangedPackages.ts
@@ -1,5 +1,6 @@
 import {
   getBranchChanges,
+  getChangesBetweenRefs,
   getDefaultRemoteBranch,
   getStagedChanges,
   getUnstagedChanges,
@@ -8,6 +9,64 @@ import {
 import { getWorkspaces } from "./getWorkspaces";
 import multimatch from "multimatch";
 import path from "path";
+
+/**
+ * Finds all packages that had been changed between two refs in the repo under cwd
+ *
+ * executes a "git diff $fromRef...$toRef" to get changes given a merge-base
+ *
+ * further explanation with the three dots:
+ *
+ * > git diff [--options] <commit>...<commit> [--] [<path>...]
+ * >
+ * >    This form is to view the changes on the branch containing and up to
+ * >    the second <commit>, starting at a common ancestor of both
+ * >    <commit>. "git diff A...B" is equivalent to "git diff
+ * >    $(git-merge-base A B) B". You can omit any one of <commit>, which
+ * >    has the same effect as using HEAD instead.
+ *
+ * @returns string[] of package names that have changed
+ */
+export function getChangedPackagesBetweenRefs(
+  cwd: string,
+  fromRef: string,
+  toRef: string = '',
+  ignoreGlobs: string[] = []
+) {
+  const workspaceInfo = getWorkspaces(cwd);
+
+  let changes = [
+    ...new Set([
+      ...(getUntrackedChanges(cwd) || []),
+      ...(getUnstagedChanges(cwd) || []),
+      ...(getChangesBetweenRefs(fromRef, toRef, [], "", cwd) || []),
+      ...(getStagedChanges(cwd) || []),
+    ]),
+  ];
+
+  const ignoreSet = new Set(multimatch(changes, ignoreGlobs));
+
+  changes = changes.filter((change) => !ignoreSet.has(change));
+
+  const changeSet = new Set<string>();
+
+  for (const change of changes) {
+    const candidates = workspaceInfo.filter(
+      (pkgPath) => change.indexOf(path.relative(cwd, pkgPath.path).replace(/\\/g, "/")) === 0
+    );
+
+    if (candidates && candidates.length > 0) {
+      const found = candidates.reduce((found, item) => {
+        return found.path.length > item.path.length ? found : item;
+      }, candidates[0]);
+      changeSet.add(found.name);
+    } else {
+      return workspaceInfo.map((pkg) => pkg.name);
+    }
+  }
+
+  return [...changeSet];
+}
 
 /**
  * Finds all packages that had been changed in the repo under cwd
@@ -26,46 +85,7 @@ import path from "path";
  *
  * @returns string[] of package names that have changed
  */
-export function getChangedPackages(
-  cwd: string,
-  target: string | undefined,
-  ignoreGlobs: string[] = []
-) {
-  const workspaceInfo = getWorkspaces(cwd);
-
+export function getChangedPackages(cwd: string, target: string | undefined, ignoreGlobs: string[] = []) {
   target = target || getDefaultRemoteBranch(undefined, cwd);
-
-  let changes = [
-    ...new Set([
-      ...(getUntrackedChanges(cwd) || []),
-      ...(getUnstagedChanges(cwd) || []),
-      ...(getBranchChanges(target, cwd) || []),
-      ...(getStagedChanges(cwd) || []),
-    ]),
-  ];
-
-  const ignoreSet = new Set(multimatch(changes, ignoreGlobs));
-
-  changes = changes.filter((change) => !ignoreSet.has(change));
-
-  const changeSet = new Set<string>();
-
-  for (const change of changes) {
-    const candidates = workspaceInfo.filter(
-      (pkgPath) =>
-        change.indexOf(path.relative(cwd, pkgPath.path).replace(/\\/g, "/")) ===
-        0
-    );
-
-    if (candidates && candidates.length > 0) {
-      const found = candidates.reduce((found, item) => {
-        return found.path.length > item.path.length ? found : item;
-      }, candidates[0]);
-      changeSet.add(found.name);
-    } else {
-      return workspaceInfo.map((pkg) => pkg.name);
-    }
-  }
-
-  return [...changeSet];
+  return getChangedPackagesBetweenRefs(cwd, target, undefined, ignoreGlobs);
 }

--- a/src/workspaces/getPackagesByFiles.ts
+++ b/src/workspaces/getPackagesByFiles.ts
@@ -1,0 +1,37 @@
+import multimatch from "multimatch";
+import path from "path";
+import { getWorkspaces } from "./getWorkspaces";
+
+/**
+ * Given a list of files, finds all packages names that contain those files
+ *
+ * @param cwd
+ * @param files
+ * @param ignoreGlobs
+ * @returns package names that have changed
+ */
+export function getPackagesByFiles(cwd: string, files: string[], ignoreGlobs: string[] = []) {
+  const workspaceInfo = getWorkspaces(cwd);
+  const ignoreSet = new Set(multimatch(files, ignoreGlobs));
+
+  files = files.filter((change) => !ignoreSet.has(change));
+
+  const packages = new Set<string>();
+
+  for (const change of files) {
+    const candidates = workspaceInfo.filter(
+      (pkgPath) => change.indexOf(path.relative(cwd, pkgPath.path).replace(/\\/g, "/")) === 0
+    );
+
+    if (candidates && candidates.length > 0) {
+      const found = candidates.reduce((found, item) => {
+        return found.path.length > item.path.length ? found : item;
+      }, candidates[0]);
+      packages.add(found.name);
+    } else {
+      return workspaceInfo.map((pkg) => pkg.name);
+    }
+  }
+
+  return [...packages];
+}


### PR DESCRIPTION
1. Refactored the bit of getting packages that contain a list of files
2. Added a specialized version of that (1) that will return every package to preserve the same semantic while detecting changed packages (usually for safety so if a repo wide file is changed, we assume all packages are changed)
3. Added a new API to detect changed packages between 2 refs
4. Added tests