### PR TITLE
feat: Support limited search for added file

### DIFF
--- a/change/workspace-tools-2022-05-06-09-14-39-asmundg-limit-rev-list-search.json
+++ b/change/workspace-tools-2022-05-06-09-14-39-asmundg-limit-rev-list-search.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "feat: Support limited search for added file",
+  "packageName": "workspace-tools",
+  "email": "asgramme@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-05-06T07:14:39.673Z"
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -264,8 +264,9 @@ export function getCurrentHash(cwd: string) {
 /**
  * Get the commit hash in which the file was first added.
  */
-export function getFileAddedHash(filename: string, cwd: string) {
-  const results = git(["rev-list", "HEAD", filename], { cwd });
+export function getFileAddedHash(filename: string, cwd: string, fromRef?: string, toRef?: string) {
+  const ref = fromRef && toRef ? `${fromRef}..${toRef}` : "HEAD";
+  const results = git(["rev-list", ref, filename], { cwd });
 
   if (results.success) {
     return results.stdout.trim().split("\n").slice(-1)[0];


### PR DESCRIPTION
If we know that a file was added in a range of commits (typically
something like origin/main..HEAD), we don't need to search the entire
repo history for the file. This can yield significant speedups in large
repos.