### PR TITLE
Split Git output by line-endings instead NUL character

### DIFF
--- a/change/workspace-tools-9df78859-10f8-46b3-b36f-122781dffada.json
+++ b/change/workspace-tools-9df78859-10f8-46b3-b36f-122781dffada.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "properly split git status --short output",
+  "packageName": "workspace-tools",
+  "email": "nickykalu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -98,7 +98,7 @@ export function getUntrackedChanges(cwd: string) {
       return [];
     }
 
-    const lines = changes.split(/\0/).filter((line) => line) || [];
+    const lines = changes.split(/[\r\n]+/).filter((line) => line) || [];
 
     const untracked: string[] = [];
 


### PR DESCRIPTION
Split git output by line endings instead of the NUL character.
