### PR TITLE
Move typedoc to devDependencies

### DIFF
--- a/change/workspace-tools-ae697b54-19bf-46be-a4b6-b27c93990fb8.json
+++ b/change/workspace-tools-ae697b54-19bf-46be-a4b6-b27c93990fb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move typedoc to devDependencies",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "globby": "^11.0.0",
     "jju": "^1.4.0",
     "multimatch": "^4.0.0",
-    "read-yaml-file": "^2.0.0",
-    "typedoc": "^0.22.15"
+    "read-yaml-file": "^2.0.0"
   },
   "devDependencies": {
     "@types/git-url-parse": "^9.0.0",
@@ -41,6 +40,7 @@
     "jest": "^25.0.0",
     "tmp": "^0.2.1",
     "ts-jest": "^25.5.1",
+    "typedoc": "^0.22.15",
     "typescript": "^4.5.4",
     "gh-pages": "^3.2.3"
   }


### PR DESCRIPTION
`typedoc` is only used at build time, so it should be in `devDependencies` rather than `dependencies`.