### PR TITLE
Add findProjectRoot path helper

### DIFF
--- a/change/workspace-tools-afd4bd79-6470-42b0-bef8-c218a89ebc6f.json
+++ b/change/workspace-tools-afd4bd79-6470-42b0-bef8-c218a89ebc6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add findProjectRoot path helper",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,10 +1,9 @@
-import path from 'path';
-import fs from 'fs';
+import path from "path";
+import fs from "fs";
+import { getWorkspaceRoot } from "./workspaces/getWorkspaceRoot";
 
 /**
- * Starting from `cwd`, searches up the directory hierarchy for `pathName`
- * @param pathName
- * @param cwd
+ * Starting from `cwd`, searches up the directory hierarchy for `pathName`.
  */
 export function searchUp(pathName: string, cwd: string) {
   const root = path.parse(cwd).root;
@@ -27,19 +26,41 @@ export function searchUp(pathName: string, cwd: string) {
   return null;
 }
 
+/**
+ * Starting from `cwd`, searches up the directory hierarchy for `.git`.
+ */
 export function findGitRoot(cwd: string) {
-  return searchUp('.git', cwd);
+  return searchUp(".git", cwd);
 }
 
+/**
+ * Starting from `cwd`, searches up the directory hierarchy for `package.json`.
+ */
 export function findPackageRoot(cwd: string) {
-  return searchUp('package.json', cwd);
+  return searchUp("package.json", cwd);
 }
 
+/**
+ * Starting from `cwd`, searches up the directory hierarchy for the workspace root,
+ * falling back to the git root if no workspace is detected.
+ */
+export function findProjectRoot(cwd: string) {
+  let workspaceRoot: string | undefined;
+  try {
+    workspaceRoot = getWorkspaceRoot(cwd);
+  } catch {}
+
+  return workspaceRoot || findGitRoot(cwd);
+}
+
+/**
+ * Get the folder containing beachball change files.
+ */
 export function getChangePath(cwd: string) {
   const gitRoot = findGitRoot(cwd);
 
   if (gitRoot) {
-    return path.join(gitRoot, 'change');
+    return path.join(gitRoot, "change");
   }
 
   return null;


### PR DESCRIPTION
Copy the `findProjectRoot` path helper from beachball since it makes sense for this to live in workspace-tools, and add docs for various path helpers.