### PR TITLE
Remove getChangePath

### DIFF
--- a/change/workspace-tools-a56528ad-d701-471f-96a3-cf47c9c8632d.json
+++ b/change/workspace-tools-a56528ad-d701-471f-96a3-cf47c9c8632d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING: Remove getChangePath because it's specific to beachball and should be defined there",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -53,19 +53,6 @@ export function findProjectRoot(cwd: string) {
   return workspaceRoot || findGitRoot(cwd);
 }
 
-/**
- * Get the folder containing beachball change files.
- */
-export function getChangePath(cwd: string) {
-  const gitRoot = findGitRoot(cwd);
-
-  if (gitRoot) {
-    return path.join(gitRoot, "change");
-  }
-
-  return null;
-}
-
 export function isChildOf(child: string, parent: string) {
   const relativePath = path.relative(child, parent);
   return /^[.\/\\]+$/.test(relativePath);


### PR DESCRIPTION
`getChangePath` is specific to beachball, so it should be defined there. I did a code search and it doesn't appear to be used anywhere else in github, but I have this marked as a breaking change (minor for 0.x) anyway.