### PR TITLE
Fix missing api

### DIFF
--- a/change/workspace-tools-50b8859f-becd-491e-86b7-e262b53cfdef.json
+++ b/change/workspace-tools-50b8859f-becd-491e-86b7-e262b53cfdef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing the missing getDependentMap API that lage uses",
+  "packageName": "workspace-tools",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/src/graph/createDependencyMap.ts
+++ b/src/graph/createDependencyMap.ts
@@ -10,7 +10,7 @@ export interface DependencyMap {
 // @internal
 export function createDependencyMap(
   packages: PackageInfos,
-  options: PackageDependenciesOptions = { withDevDependencies: true, withPeerDependencies: true}
+  options: PackageDependenciesOptions = { withDevDependencies: true, withPeerDependencies: false }
 ): DependencyMap {
   const map = {
     dependencies: new Map<string, Set<string>>(),

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,1 +1,5 @@
-export * from './createPackageGraph';
+export * from "./createPackageGraph";
+import { createDependencyMap } from "./createDependencyMap";
+
+// @deprecated - use createDependencyMap() instead
+export { createDependencyMap as getDependencyMap };

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -2,4 +2,4 @@ export * from "./createPackageGraph";
 import { createDependencyMap } from "./createDependencyMap";
 
 // @deprecated - use createDependencyMap() instead
-export { createDependencyMap as getDependencyMap };
+export { createDependencyMap as getDependentMap };


### PR DESCRIPTION
1. fixing that the peer deps aren't included by default!
2. adds the missing, but deprecated getDependentMap()