### PR TITLE
Fix missing api 2

### DIFF
--- a/change/workspace-tools-02483d70-1a35-4efe-a89b-f01961ff2a38.json
+++ b/change/workspace-tools-02483d70-1a35-4efe-a89b-f01961ff2a38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing the dependent map results",
+  "packageName": "workspace-tools",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,5 +1,8 @@
 export * from "./createPackageGraph";
+import { PackageInfos } from "../types/PackageInfo";
 import { createDependencyMap } from "./createDependencyMap";
 
 // @deprecated - use createDependencyMap() instead
-export { createDependencyMap as getDependentMap };
+export function getDependentMap(packages: PackageInfos) {
+  return createDependencyMap(packages).dependents;
+}


### PR DESCRIPTION
Okay, getDependentMap is only concerned about "dependents" not "dependencies"
