### PR TITLE
Add cleanup functions for addGitObserver

### DIFF
--- a/change/workspace-tools-c54b76ef-0079-44ee-9e8e-b3ae5583ee66.json
+++ b/change/workspace-tools-c54b76ef-0079-44ee-9e8e-b3ae5583ee66.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add cleanup functions for addGitObserver",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -35,10 +35,24 @@ let observing: boolean;
 
 /**
  * Adds an observer for the git operations, e.g. for testing
- * @param observer
+ * @returns a function to remove the observer
  */
 export function addGitObserver(observer: GitObserver) {
   observers.push(observer);
+  return () => removeGitObserver(observer);
+}
+
+/** Clear all git observers */
+export function clearGitObservers() {
+  observers.splice(0, observers.length);
+}
+
+/** Remove a git observer */
+function removeGitObserver(observer: GitObserver) {
+  const index = observers.indexOf(observer);
+  if (index > -1) {
+    observers.splice(index, 1);
+  }
 }
 
 /**


### PR DESCRIPTION
`addGitObserver` provided a way to observe calls to `git()`, but there was no way to clean up the observers, which could cause unexpected behavior in tests.

This PR adds two ways to clean up:
- Make `addGitObserver` return a cleanup function
- Add a function `clearGitObservers` which removes all observers (good for `afterEach`)
