### PR TITLE
Replace read-yaml-file with js-yaml

### DIFF
--- a/change/workspace-tools-0bf762ae-bc39-46d8-b529-595701571db6.json
+++ b/change/workspace-tools-0bf762ae-bc39-46d8-b529-595701571db6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace read-yaml-file with js-yaml",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/git-url-parse": "9.0.1",
     "@types/jest": "28.1.8",
     "@types/jju": "1.4.2",
+    "@types/js-yaml": "4.0.5",
     "@types/micromatch": "4.0.2",
     "@types/node": "14.18.29",
     "@types/tmp": "0.2.3",

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -22,8 +22,8 @@
     "git-url-parse": "^12.0.0",
     "globby": "^11.0.0",
     "jju": "^1.4.0",
-    "micromatch": "^4.0.0",
-    "read-yaml-file": "^2.0.0"
+    "js-yaml": "^4.1.0",
+    "micromatch": "^4.0.0"
   },
   "devDependencies": {
     "workspace-tools-scripts": "*"

--- a/packages/workspace-tools/src/lockfile/index.ts
+++ b/packages/workspace-tools/src/lockfile/index.ts
@@ -5,6 +5,7 @@ import { ParsedLock, PnpmLockFile, NpmLockFile } from "./types";
 import { nameAtVersion } from "./nameAtVersion";
 import { parsePnpmLock } from "./parsePnpmLock";
 import { parseNpmLock } from "./parseNpmLock";
+import { readYaml } from "./readYaml";
 
 const memoization: { [path: string]: ParsedLock } = {};
 
@@ -34,8 +35,7 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
       return memoization[pnpmLockPath];
     }
 
-    const readYamlFile = require("read-yaml-file");
-    const yaml = (await readYamlFile(pnpmLockPath)) as PnpmLockFile;
+    const yaml = readYaml<PnpmLockFile>(pnpmLockPath);
     const parsed = parsePnpmLock(yaml);
     memoization[pnpmLockPath] = parsed;
 

--- a/packages/workspace-tools/src/lockfile/readYaml.ts
+++ b/packages/workspace-tools/src/lockfile/readYaml.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+import type jsYamlType from "js-yaml";
+
+export function readYaml<TReturn>(file: string): TReturn {
+  // This is delay loaded to avoid the perf penalty of parsing YAML utilities any time the package
+  // is used (since usage of the YAML utilities is less common).
+  const jsYaml: typeof jsYamlType = require("js-yaml");
+
+  const content = fs.readFileSync(file, "utf8");
+  return jsYaml.load(content) as TReturn;
+}

--- a/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
@@ -4,6 +4,7 @@ import findUp from "find-up";
 import { getPackagePaths } from "../../getPackagePaths";
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
+import { readYaml } from "../../lockfile/readYaml";
 
 type PnpmWorkspaces = {
   packages: string[];
@@ -24,7 +25,6 @@ export function getPnpmWorkspaces(cwd: string): WorkspaceInfo {
     const pnpmWorkspacesRoot = getPnpmWorkspaceRoot(cwd);
     const pnpmWorkspacesFile = path.join(pnpmWorkspacesRoot, "pnpm-workspace.yaml");
 
-    const readYaml = require("read-yaml-file").sync;
     const pnpmWorkspaces = readYaml(pnpmWorkspacesFile) as PnpmWorkspaces;
 
     const packagePaths = getPackagePaths(pnpmWorkspacesRoot, pnpmWorkspaces.packages);

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,6 +815,11 @@
   resolved "https://registry.yarnpkg.com/@types/jju/-/jju-1.4.2.tgz#cb31d10d9e23a1b2786a9842c584b53f6f1b9086"
   integrity sha512-fbvsM6TrP3QN6791tiF6wAkmlNRwf1VARZ7sXyc5kmbfTDFhECaiS5ZFvpaciud0BoKBBFWA8hE3utOLf5XB1w==
 
+"@types/js-yaml@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+
 "@types/micromatch@4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.2.tgz#ce29c8b166a73bf980a5727b1e4a4d099965151d"
@@ -2423,7 +2428,7 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.0.0:
+js-yaml@^4.0.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==


### PR DESCRIPTION
[read-yaml-file](https://www.npmjs.com/package/read-yaml-file) is a thin wrapper around [js-yaml](https://www.npmjs.com/package/js-yaml), so we can remove a couple dependencies by switching to using js-yaml directly.