### PR TITLE
Remove find-up dependency

### DIFF
--- a/change/workspace-tools-29ce0870-38e7-4d18-9f59-730a4edaef37.json
+++ b/change/workspace-tools-29ce0870-38e7-4d18-9f59-730a4edaef37.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING CHANGE: `searchUp` now returns the full path to the item, not its parent directory. This only affects consumers that are directly using `searchUp`.",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "find-up": "^5.0.0",
     "git-url-parse": "^13.0.0",
     "globby": "^11.0.0",
     "jju": "^1.4.0",

--- a/packages/workspace-tools/src/helpers/setupFixture.ts
+++ b/packages/workspace-tools/src/helpers/setupFixture.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import findUp from "find-up";
 import fs from "fs-extra";
 import tmp from "tmp";
 import { init, stageAndCommit, gitFailFast } from "../git";
@@ -9,7 +8,7 @@ import { PackageInfo } from "../types/PackageInfo";
 // So we attempt to use its built-in cleanup mechanisms, but tests should ideally do their own cleanup too.
 tmp.setGracefulCleanup();
 
-let fixturesRoot: string | undefined;
+const fixturesRoot = path.resolve(__dirname, "../__fixtures__");
 // Temp directories are created under tempRoot.name with incrementing numeric sub-directories
 let tempRoot: tmp.DirResult | undefined;
 let tempNumber = 0;
@@ -21,10 +20,6 @@ let tempNumber = 0;
 export function setupFixture(fixtureName?: string) {
   let fixturePath: string | undefined;
   if (fixtureName) {
-    if (!fixturesRoot) {
-      fixturesRoot = findUp.sync("__fixtures__", { cwd: __dirname, type: "directory" });
-    }
-
     fixturePath = path.join(fixturesRoot!, fixtureName);
     if (!fs.existsSync(fixturePath)) {
       throw new Error(`Couldn't find fixture "${fixtureName}" under "${fixturesRoot}"`);

--- a/packages/workspace-tools/src/lockfile/index.ts
+++ b/packages/workspace-tools/src/lockfile/index.ts
@@ -1,8 +1,8 @@
 // NOTE: never place the import of lockfile implementation here, as it slows down the library as a whole
-import findUp from "find-up";
 import fs from "fs";
 import { ParsedLock, PnpmLockFile, NpmLockFile } from "./types";
 import { nameAtVersion } from "./nameAtVersion";
+import { searchUp } from "../paths";
 import { parsePnpmLock } from "./parsePnpmLock";
 import { parseNpmLock } from "./parseNpmLock";
 import { readYaml } from "./readYaml";
@@ -10,7 +10,7 @@ import { readYaml } from "./readYaml";
 const memoization: { [path: string]: ParsedLock } = {};
 
 export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
-  const yarnLockPath = await findUp(["yarn.lock", "common/config/rush/yarn.lock"], { cwd: packageRoot });
+  const yarnLockPath = searchUp(["yarn.lock", "common/config/rush/yarn.lock"], packageRoot);
 
   // First, test out whether this works for yarn
   if (yarnLockPath) {
@@ -28,7 +28,7 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
   }
 
   // Second, test out whether this works for pnpm
-  let pnpmLockPath = await findUp(["pnpm-lock.yaml", "common/config/rush/pnpm-lock.yaml"], { cwd: packageRoot });
+  let pnpmLockPath = searchUp(["pnpm-lock.yaml", "common/config/rush/pnpm-lock.yaml"], packageRoot);
 
   if (pnpmLockPath) {
     if (memoization[pnpmLockPath]) {
@@ -43,7 +43,7 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
   }
 
   // Third, try for npm workspaces
-  let npmLockPath = await findUp(["package-lock.json"], { cwd: packageRoot });
+  let npmLockPath = searchUp("package-lock.json", packageRoot);
 
   if (npmLockPath) {
     if (memoization[npmLockPath]) {

--- a/packages/workspace-tools/src/paths.ts
+++ b/packages/workspace-tools/src/paths.ts
@@ -4,27 +4,26 @@ import { getWorkspaceRoot } from "./workspaces/getWorkspaceRoot";
 import { git } from "./git";
 
 /**
- * Starting from `cwd`, searches up the directory hierarchy for `pathName`.
+ * Starting from `cwd`, searches up the directory hierarchy for `filePath`.
+ * If multiple strings are given, searches each directory level for any of them.
+ * @returns Full path to the item found, or undefined if not found.
  */
-export function searchUp(pathName: string, cwd: string) {
+export function searchUp(filePath: string | string[], cwd: string) {
+  const paths = typeof filePath === "string" ? [filePath] : filePath;
   const root = path.parse(cwd).root;
 
-  let found = false;
+  let foundPath: string | undefined;
 
-  while (!found && cwd !== root) {
-    if (fs.existsSync(path.join(cwd, pathName))) {
-      found = true;
+  while (!foundPath && cwd !== root) {
+    foundPath = paths.find((p) => fs.existsSync(path.join(cwd, p)));
+    if (foundPath) {
       break;
     }
 
     cwd = path.dirname(cwd);
   }
 
-  if (found) {
-    return cwd;
-  }
-
-  return null;
+  return foundPath ? path.join(cwd, foundPath) : undefined;
 }
 
 /**
@@ -44,7 +43,8 @@ export function findGitRoot(cwd: string) {
  * Starting from `cwd`, searches up the directory hierarchy for `package.json`.
  */
 export function findPackageRoot(cwd: string) {
-  return searchUp("package.json", cwd);
+  const jsonPath = searchUp("package.json", cwd);
+  return jsonPath && path.dirname(jsonPath);
 }
 
 /**

--- a/packages/workspace-tools/src/workspaces/implementations/index.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/index.ts
@@ -1,5 +1,5 @@
-import findUp from "find-up";
 import path from "path";
+import { searchUp } from "../../paths";
 
 export type WorkspaceImplementations = "yarn" | "pnpm" | "rush" | "npm" | "lerna";
 export interface ImplementationAndLockFile {
@@ -16,9 +16,7 @@ export function getWorkspaceImplementationAndLockFile(
     return cache[cwd];
   }
 
-  const lockFile = findUp.sync(["lerna.json", "rush.json", "yarn.lock", "pnpm-workspace.yaml", "package-lock.json"], {
-    cwd,
-  });
+  const lockFile = searchUp(["lerna.json", "rush.json", "yarn.lock", "pnpm-workspace.yaml", "package-lock.json"], cwd);
 
   if (!lockFile) {
     return;

--- a/packages/workspace-tools/src/workspaces/implementations/lerna.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/lerna.ts
@@ -1,13 +1,13 @@
-import findUp from "find-up";
 import fs from "fs";
 import jju from "jju";
 import path from "path";
 import { getPackagePaths } from "../../getPackagePaths";
+import { searchUp } from "../../paths";
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
 
 export function getLernaWorkspaceRoot(cwd: string): string {
-  const lernaJsonPath = findUp.sync("lerna.json", { cwd });
+  const lernaJsonPath = searchUp("lerna.json", cwd);
 
   if (!lernaJsonPath) {
     throw new Error("Could not find lerna workspace root");

--- a/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
@@ -1,17 +1,17 @@
 import path from "path";
-import findUp from "find-up";
 
 import { getPackagePaths } from "../../getPackagePaths";
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
 import { readYaml } from "../../lockfile/readYaml";
+import { searchUp } from "../../paths";
 
 type PnpmWorkspaces = {
   packages: string[];
 };
 
 export function getPnpmWorkspaceRoot(cwd: string): string {
-  const pnpmWorkspacesFile = findUp.sync("pnpm-workspace.yaml", { cwd });
+  const pnpmWorkspacesFile = searchUp("pnpm-workspace.yaml", cwd);
 
   if (!pnpmWorkspacesFile) {
     throw new Error("Could not find pnpm workspaces root");

--- a/packages/workspace-tools/src/workspaces/implementations/rush.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/rush.ts
@@ -1,13 +1,13 @@
-import findUp from "find-up";
 import path from "path";
 import jju from "jju";
 import fs from "fs";
 
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
+import { searchUp } from "../../paths";
 
 export function getRushWorkspaceRoot(cwd: string): string {
-  const rushJsonPath = findUp.sync("rush.json", { cwd });
+  const rushJsonPath = searchUp("rush.json", cwd);
 
   if (!rushJsonPath) {
     throw new Error("Could not find rush workspaces root");


### PR DESCRIPTION
The dependency on [`find-up`](https://www.npmjs.com/package/find-up) can be pretty trivially replaced by modifying the existing `workspace-tools` function `searchUp` to handle multiple paths and return the full item path.

This requires a breaking change to `searchUp` to return the full path to the item, not its parent directory, but this only affects consumers using `searchUp` directly (which should be rare).
