### PR TITLE
Add GIT_DEBUG environment variable

### DIFF
--- a/change/workspace-tools-2c74a4ff-b224-472b-9530-a13273dfd6e0.json
+++ b/change/workspace-tools-2c74a4ff-b224-472b-9530-a13273dfd6e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add GIT_DEBUG environment variable",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/README.md
+++ b/packages/workspace-tools/README.md
@@ -10,6 +10,10 @@ A collection of tools that are useful in a git-controlled monorepo that is manag
 
 ## Environment Variables
 
+### GIT_DEBUG
+
+Set to any value to log output for all git commands.
+
 ### GIT_MAX_BUFFER
 
 Override the `maxBuffer` value for git processes, for example if the repo is very large. `workspace-tools` uses 500MB by default.

--- a/packages/workspace-tools/src/git/git.ts
+++ b/packages/workspace-tools/src/git/git.ts
@@ -23,6 +23,8 @@ export class GitError extends Error {
  */
 const defaultMaxBuffer = process.env.GIT_MAX_BUFFER ? parseInt(process.env.GIT_MAX_BUFFER) : 500 * 1024 * 1024;
 
+const isDebug = !!process.env.GIT_DEBUG;
+
 export type GitProcessOutput = {
   stderr: string;
   stdout: string;
@@ -59,6 +61,7 @@ function removeGitObserver(observer: GitObserver) {
  * Runs git command - use this for read-only commands
  */
 export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutput {
+  isDebug && console.log(`git ${args.join(" ")}`);
   const results = spawnSync("git", args, { maxBuffer: defaultMaxBuffer, ...options });
 
   const output: GitProcessOutput = {
@@ -66,6 +69,12 @@ export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutpu
     stdout: results.stdout.toString().trimRight(),
     success: results.status === 0,
   };
+
+  if (isDebug) {
+    console.log("exited with code " + results.status);
+    output.stdout && console.log("git stdout:\n", output.stdout);
+    output.stderr && console.warn("git stderr:\n", output.stderr);
+  }
 
   // notify observers, flipping the observing bit to prevent infinite loops
   if (!observing) {


### PR DESCRIPTION
Add an environment variable for debugging git commands. This is useful when something is going wrong with a command that's wrapped with a helper method which parses the results.