### PR TITLE
Make git helpers throw on error

### DIFF
--- a/change/workspace-tools-f537b7fe-b25f-46b7-8909-ba8ab423c2aa.json
+++ b/change/workspace-tools-f537b7fe-b25f-46b7-8909-ba8ab423c2aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING CHANGE: most git helpers now throw if the git command fails (previously, the silent failures hid bugs in consuming tools). If you have a use case where one of the helpers needs an option to *not* throw, please open an issue.",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -5,9 +5,24 @@
 
 import { git, GitError, GitProcessOutput } from "./git";
 
-export function getUntrackedChanges(cwd: string) {
+export interface GetChangesBetweenRefsOptions {
+  fromRef: string;
+  toRef?: string;
+  /** Extra options to pass to `git diff` */
+  options?: string[];
+  /** Files to include */
+  pattern?: string;
+  cwd: string;
+}
+
+/**
+ * Get untracked files in the repository
+ * @param cwd Directory to run the command in
+ * @returns List of relative paths to untracked files
+ */
+export function getUntrackedChanges(cwd: string): string[] {
   try {
-    return processGitOutput(git(["ls-files", "--others", "--exclude-standard"], { cwd }));
+    return processGitOutput(git(["ls-files", "--others", "--exclude-standard"], { cwd, throwOnError: true }));
   } catch (e) {
     throw new GitError(`Cannot gather information about untracked changes`, e);
   }
@@ -30,33 +45,74 @@ export function fetchRemoteBranch(remote: string, remoteBranch: string, cwd: str
 }
 
 /**
- * Gets all the changes that have not been staged yet
- * @param cwd
+ * Gets all the changed files that have not been staged yet. Throws if the git command fails.
+ * @param cwd Directory to run the command in
+ * @returns List of relative paths to files with unstaged changes
  */
 export function getUnstagedChanges(cwd: string) {
   try {
-    return processGitOutput(git(["--no-pager", "diff", "--name-only", "--relative"], { cwd }));
+    return processGitOutput(git(["--no-pager", "diff", "--name-only", "--relative"], { cwd, throwOnError: true }));
   } catch (e) {
     throw new GitError(`Cannot gather information about unstaged changes`, e);
   }
 }
 
+/**
+ * Gets all the changed files that have not been staged yet. Throws if the git command fails.
+ * @param branch Branch to compare against (WITHOUT remote)
+ * @param cwd Directory to run the command in
+ * @returns List of relative paths to files with committed changes
+ */
 export function getChanges(branch: string, cwd: string) {
   try {
-    return processGitOutput(git(["--no-pager", "diff", "--relative", "--name-only", branch + "..."], { cwd }));
+    return processGitOutput(
+      git(["--no-pager", "diff", "--relative", "--name-only", branch + "..."], { cwd, throwOnError: true })
+    );
   } catch (e) {
     throw new GitError(`Cannot gather information about changes`, e);
   }
 }
 
 /**
- * Gets all the changes between the branch and the merge-base
+ * Gets all the changes between the branch and the merge-base. Throws if the git command fails.
+ * @param branch Branch to compare against (WITHOUT remote)
+ * @param cwd Directory to run the command in
  */
 export function getBranchChanges(branch: string, cwd: string) {
-  return getChangesBetweenRefs(branch, "", [], "", cwd);
+  return getChangesBetweenRefs({ fromRef: branch, toRef: "", cwd });
 }
 
-export function getChangesBetweenRefs(fromRef: string, toRef: string, options: string[], pattern: string, cwd: string) {
+/**
+ * Get relative paths to files that changed between `fromRef` and `toRef` (or between `fromRef` and
+ * `HEAD` if `toRef` is not specified). Throws if the git command fails.
+ * @returns Relative paths to the changed files
+ */
+export function getChangesBetweenRefs(options: GetChangesBetweenRefsOptions): string[];
+/** @deprecated Use the object param version */
+export function getChangesBetweenRefs(
+  fromRef: string,
+  toRef: string,
+  options: string[],
+  pattern: string,
+  cwd: string
+): string[];
+export function getChangesBetweenRefs(
+  fromRefOrOptions: GetChangesBetweenRefsOptions | string,
+  ...args: [string, string[], string, string] | []
+): string[] {
+  let fromRef: string;
+  let toRef: string | undefined;
+  let options: string[] | undefined;
+  let pattern: string | undefined;
+  let cwd: string;
+
+  if (typeof fromRefOrOptions === "string") {
+    fromRef = fromRefOrOptions;
+    [toRef, options, pattern, cwd] = args as [string, string[], string, string];
+  } else {
+    ({ fromRef, toRef, cwd, options, pattern } = fromRefOrOptions);
+  }
+
   try {
     return processGitOutput(
       git(
@@ -65,11 +121,11 @@ export function getChangesBetweenRefs(fromRef: string, toRef: string, options: s
           "diff",
           "--name-only",
           "--relative",
-          ...options,
-          `${fromRef}...${toRef}`,
+          ...(options || []),
+          `${fromRef}...${toRef || ""}`,
           ...(pattern ? ["--", pattern] : []),
         ],
-        { cwd }
+        { cwd, throwOnError: true }
       )
     );
   } catch (e) {
@@ -77,23 +133,38 @@ export function getChangesBetweenRefs(fromRef: string, toRef: string, options: s
   }
 }
 
+/**
+ * Gets all the changed files that have been staged but not committed. Throws if the git command fails.
+ * @param cwd Directory to run the command in
+ * @returns List of relative paths to files with staged changes
+ */
 export function getStagedChanges(cwd: string) {
   try {
-    return processGitOutput(git(["--no-pager", "diff", "--relative", "--staged", "--name-only"], { cwd }));
+    return processGitOutput(
+      git(["--no-pager", "diff", "--relative", "--staged", "--name-only"], { cwd, throwOnError: true })
+    );
   } catch (e) {
     throw new GitError(`Cannot gather information about staged changes`, e);
   }
 }
 
+/**
+ * Gets all the recent commit messages. Throws if the git command fails.
+ * @param branch Branch to compare against (WITHOUT remote)
+ * @param cwd Directory to run the command in
+ * @returns List of relative paths to files with staged changes
+ */
 export function getRecentCommitMessages(branch: string, cwd: string) {
   try {
-    const results = git(["log", "--decorate", "--pretty=format:%s", `${branch}..HEAD`], { cwd });
+    const results = git(["log", "--decorate", "--pretty=format:%s", `${branch}..HEAD`], {
+      cwd,
+      throwOnError: true,
+    });
 
-    if (!results.success) {
-      return [];
-    }
-
-    return results.stdout.split(/\n/).map((line) => line.trim());
+    return results.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => !!line);
   } catch (e) {
     throw new GitError(`Cannot gather information about recent commits`, e);
   }
@@ -102,29 +173,37 @@ export function getRecentCommitMessages(branch: string, cwd: string) {
 export function getUserEmail(cwd: string) {
   try {
     const results = git(["config", "user.email"], { cwd });
-
+    // Non-zero code in this case means the user hasn't set their email yet
     return results.success ? results.stdout : null;
   } catch (e) {
     throw new GitError(`Cannot gather information about user.email`, e);
   }
 }
 
+/**
+ * Runs `git rev-parse --abbrev-ref HEAD`. Note that if HEAD is detached, this will return
+ * literally `HEAD` instead of the branch name. Throws if the git command fails.
+ * @param cwd Directory to run the command in
+ */
 export function getBranchName(cwd: string) {
   try {
-    const results = git(["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+    const results = git(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, throwOnError: true });
 
-    return results.success ? results.stdout : null;
+    return results.stdout;
   } catch (e) {
     throw new GitError(`Cannot get branch name`, e);
   }
 }
 
 export function getFullBranchRef(branch: string, cwd: string) {
-  const showRefResults = git(["show-ref", "--heads", branch], { cwd });
-
+  const showRefResults = git(["show-ref", "--heads", branch], { cwd, throwOnError: true });
   return showRefResults.success ? showRefResults.stdout.split(" ")[1] : null;
 }
 
+/**
+ * @deprecated Deprecated due to lack of usage and unhelpful behavior (if the branch isn't found,
+ * it prints an error message and exits 0)
+ */
 export function getShortBranchName(fullBranchRef: string, cwd: string) {
   const showRefResults = git(["name-rev", "--name-only", fullBranchRef], {
     cwd,
@@ -133,96 +212,105 @@ export function getShortBranchName(fullBranchRef: string, cwd: string) {
   return showRefResults.success ? showRefResults.stdout : null;
 }
 
+/**
+ * Get the SHA1 corresponding to HEAD. Throws if the git command fails.
+ */
 export function getCurrentHash(cwd: string) {
   try {
-    const results = git(["rev-parse", "HEAD"], { cwd });
-
-    return results.success ? results.stdout : null;
+    const results = git(["rev-parse", "HEAD"], { cwd, throwOnError: true });
+    return results.stdout;
   } catch (e) {
     throw new GitError(`Cannot get current git hash`, e);
   }
 }
 
 /**
- * Get the commit hash in which the file was first added.
+ * Get the commit hash in which the file was first added. Throws if the git command fails.
  */
 export function getFileAddedHash(filename: string, cwd: string) {
-  const results = git(["rev-list", "HEAD", filename], { cwd });
-
-  if (results.success) {
-    return results.stdout.trim().split("\n").slice(-1)[0];
-  }
-
-  return undefined;
+  // This command exits 0 for untracked or newly added files
+  const results = git(["rev-list", "HEAD", filename], { cwd, throwOnError: true });
+  return results.stdout.trim().split("\n").slice(-1)[0];
 }
 
+/**
+ * Initialize a git repo with basic settings. Throws if any git command fails.
+ */
 export function init(cwd: string, email?: string, username?: string) {
   git(["init"], { cwd });
 
-  const configLines = git(["config", "--list"], { cwd }).stdout.split("\n");
+  const configLines = git(["config", "--list"], { cwd, throwOnError: true }).stdout.split("\n");
 
   if (!configLines.find((line) => line.includes("user.name"))) {
     if (!username) {
       throw new GitError("must include a username when initializing git repo");
     }
-    git(["config", "user.name", username], { cwd });
+    git(["config", "user.name", username], { cwd, throwOnError: true });
   }
 
   if (!configLines.find((line) => line.includes("user.email"))) {
     if (!email) {
       throw new Error("must include a email when initializing git repo");
     }
-    git(["config", "user.email", email], { cwd });
+    git(["config", "user.email", email], { cwd, throwOnError: true });
   }
 }
 
+/**
+ * Stage the given files/patterns. Throws if any git command fails.
+ */
 export function stage(patterns: string[], cwd: string) {
   try {
     patterns.forEach((pattern) => {
-      git(["add", pattern], { cwd });
+      git(["add", pattern], { cwd, throwOnError: true });
     });
   } catch (e) {
     throw new GitError(`Cannot stage changes`, e);
   }
 }
 
+/**
+ * Commit changes. Throws if the git command fails.
+ */
 export function commit(message: string, cwd: string, options: string[] = []) {
   try {
-    const commitResults = git(["commit", "-m", message, ...options], { cwd });
-
-    if (!commitResults.success) {
-      throw new Error(`Cannot commit changes: ${commitResults.stdout} ${commitResults.stderr}`);
-    }
+    git(["commit", "-m", message, ...options], { cwd, throwOnError: true });
   } catch (e) {
     throw new GitError(`Cannot commit changes`, e);
   }
 }
 
+/**
+ * Stage and commit the given files/patterns. Throws if any git command fails.
+ */
 export function stageAndCommit(patterns: string[], message: string, cwd: string, commitOptions: string[] = []) {
   stage(patterns, cwd);
   commit(message, cwd, commitOptions);
 }
 
+/**
+ * Revert all local changes. Throws if any git command fails.
+ */
 export function revertLocalChanges(cwd: string) {
   const stash = `workspace-tools_${new Date().getTime()}`;
-  git(["stash", "push", "-u", "-m", stash], { cwd });
-  const results = git(["stash", "list"]);
-  if (results.success) {
-    const lines = results.stdout.split(/\n/);
-    const foundLine = lines.find((line) => line.includes(stash));
+  git(["stash", "push", "-u", "-m", stash], { cwd, throwOnError: true });
 
-    if (foundLine) {
-      const matched = foundLine.match(/^[^:]+/);
-      if (matched) {
-        git(["stash", "drop", matched[0]]);
-        return true;
-      }
+  const results = git(["stash", "list"], { cwd, throwOnError: true });
+  const lines = results.stdout.split("\n");
+  const foundLine = lines.find((line) => line.includes(stash));
+
+  if (foundLine) {
+    const matched = foundLine.match(/^[^:]+/);
+    if (matched) {
+      git(["stash", "drop", matched[0]]);
+      return true;
     }
   }
-
-  return false;
 }
 
+/**
+ * Gets the branch this one is derived from. Throws if any git command fails.
+ */
 export function getParentBranch(cwd: string) {
   const branchName = getBranchName(cwd);
 
@@ -230,10 +318,10 @@ export function getParentBranch(cwd: string) {
     return null;
   }
 
-  const showBranchResult = git(["show-branch", "-a"], { cwd });
+  const showBranchResult = git(["show-branch", "-a"], { cwd, throwOnError: true });
 
   if (showBranchResult.success) {
-    const showBranchLines = showBranchResult.stdout.split(/\n/);
+    const showBranchLines = showBranchResult.stdout.split("\n");
     const parentLine = showBranchLines.find(
       (line) => line.includes("*") && !line.includes(branchName) && !line.includes("publish_")
     );
@@ -246,24 +334,15 @@ export function getParentBranch(cwd: string) {
 }
 
 export function getRemoteBranch(branch: string, cwd: string) {
+  // Non-zero exit code means the branch hasn't been pushed to a remote yet (which is likely fine)
   const results = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", `${branch}@\{u\}`], { cwd });
-
-  if (results.success) {
-    return results.stdout.trim();
-  }
-
-  return null;
+  return results.success ? results.stdout.trim() : null;
 }
 
 export function parseRemoteBranch(branch: string) {
-  const firstSlashPos = branch.indexOf("/", 0);
-  const remote = branch.substring(0, firstSlashPos);
-  const remoteBranch = branch.substring(firstSlashPos + 1);
+  const [remote, remoteBranch] = branch.split("/", 2);
 
-  return {
-    remote,
-    remoteBranch,
-  };
+  return { remote, remoteBranch };
 }
 
 /**
@@ -273,22 +352,22 @@ export function getDefaultBranch(cwd: string) {
   const result = git(["config", "init.defaultBranch"], { cwd });
 
   // Default to the legacy 'master' for backwards compat and old git clients
+  // (non-zero exit code here means "not set" which is fine)
   return result.success ? result.stdout.trim() : "master";
 }
 
+/**
+ * List paths to files/patterns. Throws if the git command fails.
+ */
 export function listAllTrackedFiles(patterns: string[], cwd: string) {
-  const results = git(["ls-files", ...patterns], { cwd });
+  const results = git(["ls-files", ...patterns], { cwd, throwOnError: true });
 
-  return results.success && results.stdout.trim() ? results.stdout.trim().split(/\n/) : [];
+  return results.stdout.split("\n").filter((line) => !!line);
 }
 
 function processGitOutput(output: GitProcessOutput) {
-  if (!output.success) {
-    return [];
-  }
-
   return output.stdout
-    .split(/\n/)
+    .split("\n")
     .map((line) => line.trim())
     .filter((line) => !!line && !line.includes("node_modules"));
 }

--- a/packages/workspace-tools/src/workspaces/getChangedPackages.ts
+++ b/packages/workspace-tools/src/workspaces/getChangedPackages.ts
@@ -33,10 +33,10 @@ export function getChangedPackagesBetweenRefs(
 ) {
   let changes = [
     ...new Set([
-      ...(getUntrackedChanges(cwd) || []),
-      ...(getUnstagedChanges(cwd) || []),
-      ...(getChangesBetweenRefs(fromRef, toRef, [], "", cwd) || []),
-      ...(getStagedChanges(cwd) || []),
+      ...getUntrackedChanges(cwd),
+      ...getUnstagedChanges(cwd),
+      ...getChangesBetweenRefs({ fromRef, toRef, cwd }),
+      ...getStagedChanges(cwd),
     ]),
   ];
 
@@ -64,10 +64,10 @@ export function getChangedPackages(cwd: string, target: string | undefined, igno
   const targetBranch = target || getDefaultRemoteBranch({ cwd });
   let changes = [
     ...new Set([
-      ...(getUntrackedChanges(cwd) || []),
-      ...(getUnstagedChanges(cwd) || []),
-      ...(getBranchChanges(targetBranch, cwd) || []),
-      ...(getStagedChanges(cwd) || []),
+      ...getUntrackedChanges(cwd),
+      ...getUnstagedChanges(cwd),
+      ...getBranchChanges(targetBranch, cwd),
+      ...getStagedChanges(cwd),
     ]),
   ];
 


### PR DESCRIPTION
Previously, a lot of the git helpers silently swallowed if the git command exited non-zero, which tended to hide some pretty severe bugs in consuming packages (such as beachball, see https://github.com/microsoft/beachball/pull/780).

This PR updates almost all of the git helpers to explicitly throw errors if the git command exits non-zero. I think this approach is preferable because it likely indicates invalid input to the command or an invalid repo state, and either of those is something that should be explicitly surfaced (so it can be fixed) rather than hidden.

I considered adding a flag to each helper that determines whether to throw, but I think in almost all cases, throwing by default is preferable. If anyone has a use case for needing one of the helpers not to throw (which can't be covered by try/catch on the consumer end), they can open an issue.