### PR TITLE
Support non workspaces for getPackageInfos()

### DIFF
--- a/change/workspace-tools-136735b0-9eb6-4204-8172-76d1b5884525.json
+++ b/change/workspace-tools-136735b0-9eb6-4204-8172-76d1b5884525.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "added support for non-workspaces in getPackageInfos",
+  "packageName": "workspace-tools",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/src/getPackageInfos.ts
+++ b/packages/workspace-tools/src/getPackageInfos.ts
@@ -1,10 +1,15 @@
 import fs from "fs";
+import path from "path";
 import { PackageInfos } from "./types/PackageInfo";
 import { infoFromPackageJson } from "./infoFromPackageJson";
 import { getAllPackageJsonFiles } from "./workspaces/workspaces";
 
 export function getPackageInfos(cwd: string) {
-  const packageJsonFiles = getAllPackageJsonFiles(cwd);
+  let packageJsonFiles = getAllPackageJsonFiles(cwd);
+
+  if (packageJsonFiles.length === 0 && fs.existsSync(path.join(cwd, "package.json"))) {
+    packageJsonFiles = [path.join(cwd, "package.json")];
+  }
 
   const packageInfos: PackageInfos = {};
   if (packageJsonFiles && packageJsonFiles.length > 0) {

--- a/packages/workspace-tools/src/workspaces/workspaces.ts
+++ b/packages/workspace-tools/src/workspaces/workspaces.ts
@@ -8,7 +8,7 @@ const cache = new Map<string, string[]>();
  */
 export function getAllPackageJsonFiles(cwd: string) {
   if (cache.has(cwd)) {
-    return cache.get(cwd);
+    return cache.get(cwd)!;
   }
 
   const workspaces = getWorkspaces(cwd);


### PR DESCRIPTION
In order to support Cloudpack & beyond, sometimes getPackageInfos() is called inside a non-workspace. We should still support that scenario.