### PR TITLE
getRecentCommitMessages: return empty array if no commits

### DIFF
--- a/change/workspace-tools-111fb811-de8e-4bc5-8902-ac403da1326f.json
+++ b/change/workspace-tools-111fb811-de8e-4bc5-8902-ac403da1326f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "getRecentCommitMessages: return empty array if no commits",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -93,7 +93,10 @@ export function getRecentCommitMessages(branch: string, cwd: string) {
       return [];
     }
 
-    return results.stdout.split(/\n/).map((line) => line.trim());
+    return results.stdout
+      .trim()
+      .split(/\n/)
+      .map((line) => line.trim());
   } catch (e) {
     throw new GitError(`Cannot gather information about recent commits`, e);
   }


### PR DESCRIPTION
`getRecentCommitMessages` wasn't trimming the git output before splitting lines, which made it return `['']` for a new branch. Fix is to trim before splitting. (ref: https://github.com/microsoft/beachball/issues/793)