### PR TITLE
Add optional verbose logging for getWorkspaces helpers

### DIFF
--- a/change/workspace-tools-bf66df53-279c-4971-bdae-38cd64348e51.json
+++ b/change/workspace-tools-bf66df53-279c-4971-bdae-38cd64348e51.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add optional verbose logging for getWorkspaces helpers",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/src/lockfile/index.ts
+++ b/packages/workspace-tools/src/lockfile/index.ts
@@ -73,7 +73,7 @@ export async function parseLockFile(packageRoot: string): Promise<ParsedLock> {
     try {
       npmLockJson = fs.readFileSync(npmLockPath, "utf-8");
     } catch {
-      throw new Error("Couldn’t parse package-lock.json.");
+      throw new Error("Couldn't read package-lock.json");
     }
 
     const npmLock: NpmLockFile = JSON.parse(npmLockJson.toString());

--- a/packages/workspace-tools/src/logging.ts
+++ b/packages/workspace-tools/src/logging.ts
@@ -1,0 +1,9 @@
+/**
+ * Helper that logs an error to `console.warn` if `process.env.VERBOSE` is set.
+ * This should be replaced with a proper logging system eventually.
+ */
+export function logVerboseWarning(description: string, err?: unknown) {
+  if (process.env.VERBOSE) {
+    console.warn(`${description}${err ? ":\n" : ""}`, (err as Error | undefined)?.stack || err || "");
+  }
+}

--- a/packages/workspace-tools/src/paths.ts
+++ b/packages/workspace-tools/src/paths.ts
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs";
 import { getWorkspaceRoot } from "./workspaces/getWorkspaceRoot";
 import { git } from "./git";
+import { logVerboseWarning } from "./logging";
 
 /**
  * Starting from `cwd`, searches up the directory hierarchy for `filePath`.
@@ -55,8 +56,13 @@ export function findProjectRoot(cwd: string) {
   let workspaceRoot: string | undefined;
   try {
     workspaceRoot = getWorkspaceRoot(cwd);
-  } catch {}
+  } catch (err) {
+    logVerboseWarning(`Error getting workspace root for ${cwd}`, err);
+  }
 
+  if (!workspaceRoot) {
+    logVerboseWarning(`Could not find workspace root for ${cwd}. Falling back to git root.`);
+  }
   return workspaceRoot || findGitRoot(cwd);
 }
 

--- a/packages/workspace-tools/src/workspaces/implementations/lerna.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/lerna.ts
@@ -5,6 +5,7 @@ import { getPackagePaths } from "../../getPackagePaths";
 import { searchUp } from "../../paths";
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
+import { logVerboseWarning } from "../../logging";
 
 export function getLernaWorkspaceRoot(cwd: string): string {
   const lernaJsonPath = searchUp("lerna.json", cwd);
@@ -26,7 +27,8 @@ export function getLernaWorkspaces(cwd: string): WorkspaceInfo {
     const packagePaths = getPackagePaths(lernaWorkspaceRoot, lernaConfig.packages);
     const workspaceInfo = getWorkspacePackageInfo(packagePaths);
     return workspaceInfo;
-  } catch {
+  } catch (err) {
+    logVerboseWarning(`Error getting lerna workspaces for ${cwd}`, err);
     return [];
   }
 }

--- a/packages/workspace-tools/src/workspaces/implementations/packageJsonWorkspaces.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/packageJsonWorkspaces.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { getWorkspaceManagerAndRoot } from ".";
 import { getPackagePaths, getPackagePathsAsync } from "../../getPackagePaths";
 import { getWorkspacePackageInfo, getWorkspacePackageInfoAsync } from "../getWorkspacePackageInfo";
+import { logVerboseWarning } from "../../logging";
 
 type PackageJsonWorkspaces = {
   workspaces?:
@@ -47,7 +48,8 @@ export function getWorkspaceInfoFromWorkspaceRoot(packageJsonWorkspacesRoot: str
     const packages = getPackages(rootPackageJson);
     const packagePaths = getPackagePaths(packageJsonWorkspacesRoot, packages);
     return getWorkspacePackageInfo(packagePaths);
-  } catch {
+  } catch (err) {
+    logVerboseWarning(`Error getting workspace info for ${packageJsonWorkspacesRoot}`, err);
     return [];
   }
 }
@@ -58,7 +60,8 @@ export async function getWorkspaceInfoFromWorkspaceRootAsync(packageJsonWorkspac
     const packages = getPackages(rootPackageJson);
     const packagePaths = await getPackagePathsAsync(packageJsonWorkspacesRoot, packages);
     return getWorkspacePackageInfoAsync(packagePaths);
-  } catch {
+  } catch (err) {
+    logVerboseWarning(`Error getting workspace info for ${packageJsonWorkspacesRoot}`, err);
     return [];
   }
 }

--- a/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
@@ -5,6 +5,7 @@ import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
 import { readYaml } from "../../lockfile/readYaml";
 import { searchUp } from "../../paths";
+import { logVerboseWarning } from "../../logging";
 
 type PnpmWorkspaces = {
   packages: string[];
@@ -31,7 +32,8 @@ export function getPnpmWorkspaces(cwd: string): WorkspaceInfo {
     const workspaceInfo = getWorkspacePackageInfo(packagePaths);
 
     return workspaceInfo;
-  } catch {
+  } catch (err) {
+    logVerboseWarning(`Error getting pnpm workspaces for ${cwd}`, err);
     return [];
   }
 }

--- a/packages/workspace-tools/src/workspaces/implementations/rush.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/rush.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import { WorkspaceInfo } from "../../types/WorkspaceInfo";
 import { getWorkspacePackageInfo } from "../getWorkspacePackageInfo";
 import { searchUp } from "../../paths";
+import { logVerboseWarning } from "../../logging";
 
 export function getRushWorkspaceRoot(cwd: string): string {
   const rushJsonPath = searchUp("rush.json", cwd);
@@ -27,7 +28,8 @@ export function getRushWorkspaces(cwd: string): WorkspaceInfo {
     const root = path.dirname(rushJsonPath);
 
     return getWorkspacePackageInfo(rushConfig.projects.map((project) => path.join(root, project.projectFolder)));
-  } catch {
+  } catch (err) {
+    logVerboseWarning(`Error getting rush workspaces for ${cwd}`, err);
     return [];
   }
 }


### PR DESCRIPTION
Previously, the helpers for `getWorkspaces` and related methods completely swallowed errors, which sometimes made debugging difficult. This PR adds `console.warn` logs if `process.env.VERBOSE` is set. 

Implementation notes:
- It's possible that it would be helpful to *always* log these warnings, but I made them optional for now because I'm not sure how noisy that would end up being.
- A complete logger/log level system would be good to add at some point, but this is an incremental improvement.