### PR TITLE
Minor fixes to new async workspace/package methods

### DIFF
--- a/change/workspace-tools-dec05ce2-9367-4314-9a9c-56df7b0c452a.json
+++ b/change/workspace-tools-dec05ce2-9367-4314-9a9c-56df7b0c452a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor fixes to new async workspace/package methods",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Minor follow-ups from #269 
- Make `getWorkspacePackageInfoAsync` actually read the files asynchronously (previously it was reading them synchronously despite the name)
- Combine core logic for `getPackagePaths` sync/async to avoid any future bugs/inconsistency
