### PR TITLE
Add more doc comments for getWorkspaces and related

### DIFF
--- a/change/workspace-tools-cf66df53-279c-4971-bdae-38cd64348e52.json
+++ b/change/workspace-tools-cf66df53-279c-4971-bdae-38cd64348e52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more doc comments for getWorkspaces and related",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -66,13 +66,13 @@ export function findPackageRoot(cwd: string): string | undefined;
 // @public
 export function findProjectRoot(cwd: string): string;
 
-// @public (undocumented)
+// @public
 export function findWorkspacePath(workspaces: WorkspaceInfo, packageName: string): string | undefined;
 
 // @public
 export function getAllPackageJsonFiles(cwd: string): string[];
 
-// @public (undocumented)
+// @public
 export function getAllPackageJsonFilesAsync(cwd: string): Promise<string[]>;
 
 // @public
@@ -155,7 +155,7 @@ export function getParentBranch(cwd: string): string | null;
 // @public (undocumented)
 export function getPnpmWorkspaceRoot(cwd: string): string;
 
-// @public (undocumented)
+// @public
 export function getPnpmWorkspaces(cwd: string): WorkspaceInfo;
 
 // @public (undocumented)
@@ -167,7 +167,7 @@ export function getRemoteBranch(branch: string, cwd: string): string | null;
 // @public (undocumented)
 export function getRushWorkspaceRoot(cwd: string): string;
 
-// @public (undocumented)
+// @public
 export function getRushWorkspaces(cwd: string): WorkspaceInfo;
 
 // @public
@@ -202,19 +202,19 @@ export function getUntrackedChanges(cwd: string): string[];
 // @public (undocumented)
 export function getUserEmail(cwd: string): string | null;
 
-// @public (undocumented)
+// @public
 export function getWorkspaceRoot(cwd: string): string | undefined;
 
-// @public (undocumented)
+// @public
 export function getWorkspaces(cwd: string): WorkspaceInfo;
 
-// @public (undocumented)
+// @public
 export function getWorkspacesAsync(cwd: string): Promise<WorkspaceInfo>;
 
 // @public (undocumented)
 export function getYarnWorkspaceRoot(cwd: string): string;
 
-// @public (undocumented)
+// @public
 export function getYarnWorkspaces(cwd: string): WorkspaceInfo;
 
 // @public
@@ -440,7 +440,7 @@ export function stage(patterns: string[], cwd: string): void;
 // @public (undocumented)
 export function stageAndCommit(patterns: string[], message: string, cwd: string, commitOptions?: string[]): void;
 
-// @public (undocumented)
+// @public
 export type WorkspaceInfo = {
     name: string;
     path: string;

--- a/packages/workspace-tools/src/types/WorkspaceInfo.ts
+++ b/packages/workspace-tools/src/types/WorkspaceInfo.ts
@@ -1,5 +1,12 @@
 import { PackageInfo } from "./PackageInfo";
 
+/**
+ * Array with names, paths, and package.json contents for each package in a workspace.
+ *
+ * The method name is somewhat misleading due to the double meaning of "workspace", but it's retained
+ * for compatibility. "Workspace" here refers to an individual package, in the sense of the `workspaces`
+ * package.json config used by npm/yarn (instead of referring to the entire monorepo).
+ */
 export type WorkspaceInfo = {
   name: string;
   path: string;

--- a/packages/workspace-tools/src/workspaces/findWorkspacePath.ts
+++ b/packages/workspace-tools/src/workspaces/findWorkspacePath.ts
@@ -1,5 +1,12 @@
 import { WorkspaceInfo } from "../types/WorkspaceInfo";
 
+/**
+ * Find the path for a particular package name from an array of info about packages within a workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ * @param workspaces Array of info about packages within a workspace
+ * @param packageName Package name to find
+ * @returns Package path if found, or undefined
+ */
 export function findWorkspacePath(workspaces: WorkspaceInfo, packageName: string): string | undefined {
   const workspace = workspaces.find(({ name }) => name === packageName);
 

--- a/packages/workspace-tools/src/workspaces/getWorkspacePackageInfo.ts
+++ b/packages/workspace-tools/src/workspaces/getWorkspacePackageInfo.ts
@@ -5,6 +5,16 @@ import { WorkspaceInfo } from "../types/WorkspaceInfo";
 import { PackageInfo } from "../types/PackageInfo";
 import { logVerboseWarning } from "../logging";
 
+/**
+ * Get an array with names, paths, and package.json contents for each of the given package paths
+ * within a workspace.
+ *
+ * This is an internal helper used by `getWorkspaces` implementations for different managers.
+ * (See `../getWorkspaces` for why it's named this way.)
+ * @param packagePaths Paths to packages within a workspace
+ * @returns Array of workspace package infos
+ * @internal
+ */
 export function getWorkspacePackageInfo(packagePaths: string[]): WorkspaceInfo {
   if (!packagePaths) {
     return [];
@@ -33,6 +43,16 @@ export function getWorkspacePackageInfo(packagePaths: string[]): WorkspaceInfo {
   }, []);
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each of the given package paths
+ * within a workspace.
+ *
+ * This is an internal helper used by `getWorkspaces` implementations for different managers.
+ * (See `../getWorkspaces` for why it's named this way.)
+ * @param packagePaths Paths to packages within a workspace
+ * @returns Array of workspace package infos
+ * @internal
+ */
 export async function getWorkspacePackageInfoAsync(packagePaths: string[]): Promise<WorkspaceInfo> {
   if (!packagePaths) {
     return [];

--- a/packages/workspace-tools/src/workspaces/getWorkspaceRoot.ts
+++ b/packages/workspace-tools/src/workspaces/getWorkspaceRoot.ts
@@ -1,5 +1,9 @@
 import { getWorkspaceUtilities } from "./implementations";
 
+/**
+ * Get the root directory of a workspace/monorepo, defined as the directory where the workspace
+ * manager config file is located.
+ */
 export function getWorkspaceRoot(cwd: string): string | undefined {
   const impl = getWorkspaceUtilities(cwd);
   return impl?.getWorkspaceRoot(cwd);

--- a/packages/workspace-tools/src/workspaces/getWorkspaces.ts
+++ b/packages/workspace-tools/src/workspaces/getWorkspaces.ts
@@ -1,23 +1,38 @@
 import { getWorkspaceUtilities, getWorkspaceManager } from "./implementations";
-
 import { WorkspaceInfo } from "../types/WorkspaceInfo";
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a workspace.
+ * The list of included packages is based on the workspace manager's config file.
+ *
+ * The method name is somewhat misleading due to the double meaning of "workspace", but it's retained
+ * for compatibility. "Workspace" here refers to an individual package, in the sense of the `workspaces`
+ * package.json config used by npm/yarn (instead of referring to the entire monorepo).
+ */
 export function getWorkspaces(cwd: string): WorkspaceInfo {
-  const impl = getWorkspaceUtilities(cwd);
-  return impl?.getWorkspaces(cwd) || [];
+  const utils = getWorkspaceUtilities(cwd);
+  return utils?.getWorkspaces(cwd) || [];
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a workspace.
+ * The list of included packages is based on the workspace manager's config file.
+ *
+ * The method name is somewhat misleading due to the double meaning of "workspace", but it's retained
+ * for compatibility. "Workspace" here refers to an individual package, in the sense of the `workspaces`
+ * package.json config used by npm/yarn (instead of referring to the entire monorepo).
+ */
 export async function getWorkspacesAsync(cwd: string): Promise<WorkspaceInfo> {
-  const impl = getWorkspaceUtilities(cwd);
+  const utils = getWorkspaceUtilities(cwd);
 
-  if (!impl) {
+  if (!utils) {
     return [];
   }
 
-  if (!impl.getWorkspacesAsync) {
+  if (!utils.getWorkspacesAsync) {
     const managerName = getWorkspaceManager(cwd);
     throw new Error(`${cwd} is using ${managerName} which has not been converted to async yet`);
   }
 
-  return impl.getWorkspacesAsync(cwd);
+  return utils.getWorkspacesAsync(cwd);
 }

--- a/packages/workspace-tools/src/workspaces/implementations/index.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/index.ts
@@ -9,8 +9,28 @@ import type * as PnpmUtilities from "./pnpm";
 import type * as RushUtilities from "./rush";
 import type * as YarnUtilities from "./yarn";
 
+export interface WorkspaceUtilities {
+  /**
+   * Get the root directory of a workspace/monorepo, defined as the directory where the workspace
+   * manager config file is located.
+   */
+  getWorkspaceRoot: (cwd: string) => string;
+  /**
+   * Get an array with names, paths, and package.json contents for each package in a workspace.
+   * (See `../getWorkspaces` for why it's named this way.)
+   */
+  getWorkspaces: (cwd: string) => WorkspaceInfo;
+  /**
+   * Get an array with names, paths, and package.json contents for each package in a workspace.
+   * (See `../getWorkspaces` for why it's named this way.)
+   */
+  getWorkspacesAsync?: (cwd: string) => Promise<WorkspaceInfo>;
+}
+
 export interface WorkspaceManagerAndRoot {
+  /** Workspace manager name */
   manager: WorkspaceManager;
+  /** Workspace root, where the manager configuration file is located */
   root: string;
 }
 const workspaceCache = new Map<string, WorkspaceManagerAndRoot | undefined>();
@@ -75,13 +95,7 @@ export function getWorkspaceManager(cwd: string, cache = workspaceCache): Worksp
  * Get utility implementations for the workspace manager of `cwd`.
  * Returns undefined if the manager can't be determined.
  */
-export function getWorkspaceUtilities(cwd: string):
-  | {
-      getWorkspaceRoot: (cwd: string) => string;
-      getWorkspaces: (cwd: string) => WorkspaceInfo;
-      getWorkspacesAsync?: (cwd: string) => Promise<WorkspaceInfo>;
-    }
-  | undefined {
+export function getWorkspaceUtilities(cwd: string): WorkspaceUtilities | undefined {
   const manager = getWorkspaceManager(cwd);
 
   switch (manager) {

--- a/packages/workspace-tools/src/workspaces/implementations/lerna.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/lerna.ts
@@ -17,6 +17,10 @@ export function getLernaWorkspaceRoot(cwd: string): string {
   return path.dirname(lernaJsonPath);
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a lerna workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export function getLernaWorkspaces(cwd: string): WorkspaceInfo {
   try {
     const lernaWorkspaceRoot = getLernaWorkspaceRoot(cwd);

--- a/packages/workspace-tools/src/workspaces/implementations/npm.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/npm.ts
@@ -15,11 +15,19 @@ export function getNpmWorkspaceRoot(cwd: string): string {
   return npmWorkspacesRoot;
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in an npm workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export function getNpmWorkspaces(cwd: string): WorkspaceInfo {
   const npmWorkspacesRoot = getNpmWorkspaceRoot(cwd);
   return getWorkspaceInfoFromWorkspaceRoot(npmWorkspacesRoot);
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in an npm workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export async function getNpmWorkspacesAsync(cwd: string): Promise<WorkspaceInfo> {
   const npmWorkspacesRoot = getNpmWorkspaceRoot(cwd);
   return await getWorkspaceInfoFromWorkspaceRootAsync(npmWorkspacesRoot);

--- a/packages/workspace-tools/src/workspaces/implementations/packageJsonWorkspaces.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/packageJsonWorkspaces.ts
@@ -42,6 +42,10 @@ function getPackages(packageJson: PackageJsonWorkspaces): string[] {
   return workspaces.packages;
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in an npm/yarn workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export function getWorkspaceInfoFromWorkspaceRoot(packageJsonWorkspacesRoot: string) {
   try {
     const rootPackageJson = getRootPackageJson(packageJsonWorkspacesRoot);
@@ -54,6 +58,10 @@ export function getWorkspaceInfoFromWorkspaceRoot(packageJsonWorkspacesRoot: str
   }
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in an npm/yarn workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export async function getWorkspaceInfoFromWorkspaceRootAsync(packageJsonWorkspacesRoot: string) {
   try {
     const rootPackageJson = getRootPackageJson(packageJsonWorkspacesRoot);

--- a/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/pnpm.ts
@@ -7,7 +7,7 @@ import { readYaml } from "../../lockfile/readYaml";
 import { searchUp } from "../../paths";
 import { logVerboseWarning } from "../../logging";
 
-type PnpmWorkspaces = {
+type PnpmWorkspaceYaml = {
   packages: string[];
 };
 
@@ -21,12 +21,16 @@ export function getPnpmWorkspaceRoot(cwd: string): string {
   return path.dirname(pnpmWorkspacesFile);
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a pnpm workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export function getPnpmWorkspaces(cwd: string): WorkspaceInfo {
   try {
     const pnpmWorkspacesRoot = getPnpmWorkspaceRoot(cwd);
     const pnpmWorkspacesFile = path.join(pnpmWorkspacesRoot, "pnpm-workspace.yaml");
 
-    const pnpmWorkspaces = readYaml(pnpmWorkspacesFile) as PnpmWorkspaces;
+    const pnpmWorkspaces = readYaml(pnpmWorkspacesFile) as PnpmWorkspaceYaml;
 
     const packagePaths = getPackagePaths(pnpmWorkspacesRoot, pnpmWorkspaces.packages);
     const workspaceInfo = getWorkspacePackageInfo(packagePaths);

--- a/packages/workspace-tools/src/workspaces/implementations/rush.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/rush.ts
@@ -17,6 +17,10 @@ export function getRushWorkspaceRoot(cwd: string): string {
   return path.dirname(rushJsonPath);
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a rush workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export function getRushWorkspaces(cwd: string): WorkspaceInfo {
   try {
     const rushWorkspaceRoot = getRushWorkspaceRoot(cwd);

--- a/packages/workspace-tools/src/workspaces/implementations/yarn.ts
+++ b/packages/workspace-tools/src/workspaces/implementations/yarn.ts
@@ -15,11 +15,19 @@ export function getYarnWorkspaceRoot(cwd: string): string {
   return yarnWorkspacesRoot;
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a yarn workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export function getYarnWorkspaces(cwd: string): WorkspaceInfo {
   const yarnWorkspacesRoot = getYarnWorkspaceRoot(cwd);
   return getWorkspaceInfoFromWorkspaceRoot(yarnWorkspacesRoot);
 }
 
+/**
+ * Get an array with names, paths, and package.json contents for each package in a yarn workspace.
+ * (See `../getWorkspaces` for why it's named this way.)
+ */
 export async function getYarnWorkspacesAsync(cwd: string): Promise<WorkspaceInfo> {
   const yarnWorkspacesRoot = getYarnWorkspaceRoot(cwd);
   return await getWorkspaceInfoFromWorkspaceRootAsync(yarnWorkspacesRoot);

--- a/packages/workspace-tools/src/workspaces/workspaces.ts
+++ b/packages/workspace-tools/src/workspaces/workspaces.ts
@@ -3,10 +3,12 @@ import { getWorkspaces, getWorkspacesAsync } from "./getWorkspaces";
 const cache = new Map<string, string[]>();
 
 /**
- * Get paths to every package.json in the workspace, given a cwd
- * @param cwd
+ * Get paths to every package.json in the workspace, given a cwd.
+ *
+ * **WARNING**: On first call for a given `cwd`, this will **read ALL package.json files,
+ * not only their paths**!
  */
-export function getAllPackageJsonFiles(cwd: string) {
+export function getAllPackageJsonFiles(cwd: string): string[] {
   if (cache.has(cwd)) {
     return cache.get(cwd)!;
   }
@@ -23,7 +25,13 @@ export function _resetPackageJsonFilesCache() {
   cache.clear();
 }
 
-export async function getAllPackageJsonFilesAsync(cwd: string) {
+/**
+ * Get paths to every package.json in the workspace, given a cwd.
+ *
+ * **WARNING**: On first call for a given `cwd`, this will **read ALL package.json files,
+ * not only their paths**!
+ */
+export async function getAllPackageJsonFilesAsync(cwd: string): Promise<string[]> {
   if (cache.has(cwd)) {
     return cache.get(cwd)!;
   }


### PR DESCRIPTION
The naming for `getWorkspaces` and related methods is kind of misleading due to the double meaning of "workspace." Here, "workspace" refers to an individual package, in the sense of the `workspaces` package.json config used by npm/yarn, instead of referring to the entire monorepo.

Ideally I'd like to completely change the naming of these methods, but this is harder since they're known to be used in quite a few other places, plus it's ambiguous what the name ought to be. So an incremental improvement is adding a lot of very explicit comments about the methods' inputs and outputs.

(Having these comments will also make it easier to address the issue where `getPackageInfos` reads all package.json files twice--previously due to the weird naming, it was hard to even understand what a method did without reading the implementation every time, especially since there are many methods with very similar names.)