### PR TITLE
Add full spawnSync result to git helper

### DIFF
--- a/change/workspace-tools-0c0154f9-f87c-44c3-8b9c-80562dc1aa04.json
+++ b/change/workspace-tools-0c0154f9-f87c-44c3-8b9c-80562dc1aa04.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add full spawnSync result to git helper",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import { SpawnSyncOptions } from 'child_process';
+import { SpawnSyncReturns } from 'child_process';
 
 // @public
 export function addGitObserver(observer: GitObserver): () => void;
@@ -248,7 +249,7 @@ export type GitProcessOutput = {
     stderr: string;
     stdout: string;
     success: boolean;
-};
+} & Omit<SpawnSyncReturns<string | Buffer>, "stdout" | "stderr">;
 
 // @public (undocumented)
 export function init(cwd: string, email?: string, username?: string): void;

--- a/packages/workspace-tools/src/git/git.ts
+++ b/packages/workspace-tools/src/git/git.ts
@@ -2,6 +2,7 @@
 // Basic git wrappers
 //
 
+import { SpawnSyncReturns } from "child_process";
 import { spawnSync, SpawnSyncOptions } from "child_process";
 
 export class GitError extends Error {
@@ -29,7 +30,8 @@ export type GitProcessOutput = {
   stderr: string;
   stdout: string;
   success: boolean;
-};
+} & Omit<SpawnSyncReturns<string | Buffer>, "stdout" | "stderr">;
+
 /** Observes the git operations called from `git()` or `gitFailFast()` */
 export type GitObserver = (args: string[], output: GitProcessOutput) => void;
 const observers: GitObserver[] = [];
@@ -65,6 +67,7 @@ export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutpu
   const results = spawnSync("git", args, { maxBuffer: defaultMaxBuffer, ...options });
 
   const output: GitProcessOutput = {
+    ...results,
     // these may be undefined if stdio: inherit is set
     stderr: (results.stderr || "").toString().trimRight(),
     stdout: (results.stdout || "").toString().trimRight(),


### PR DESCRIPTION
Sometimes it's helpful to have the full output from a git command, for example to inspect the error reason.