### PR TITLE
Add bin for grapher

### DIFF
--- a/change/@ws-tools-grapher-44f579ba-c61e-4bb3-b636-3e07c4134bdc.json
+++ b/change/@ws-tools-grapher-44f579ba-c61e-4bb3-b636-3e07c4134bdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `bin` and prevent importing the package",
+  "packageName": "@ws-tools/grapher",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/workspace-tools-63ff6dc4-8f44-4e2d-be6a-6d10c7cf09cb.json
+++ b/change/workspace-tools-63ff6dc4-8f44-4e2d-be6a-6d10c7cf09cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync version after failed publish",
+  "packageName": "workspace-tools",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "10.1.0",
     "gh-pages": "4.0.0",
     "jest": "29.5.0",
-    "lage": "2.5.2",
+    "lage": "2.6.2",
     "prettier": "2.8.7",
     "tmp": "0.2.1",
     "ts-jest": "29.1.0",
@@ -50,8 +50,8 @@
     "typescript": "4.5.4"
   },
   "resolutions": {
-    "**/beachball/workspace-tools": "npm:workspace-tools@0.33.0",
-    "**/lage/workspace-tools": "npm:workspace-tools@0.33.0",
-    "**/lage/**/workspace-tools": "npm:workspace-tools@0.33.0"
+    "**/beachball/workspace-tools": "npm:workspace-tools@0.34.3",
+    "**/lage/workspace-tools": "npm:workspace-tools@0.34.3",
+    "**/lage/**/workspace-tools": "npm:workspace-tools@0.34.3"
   }
 }

--- a/packages/grapher/bin/grapher.js
+++ b/packages/grapher/bin/grapher.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../lib/index");

--- a/packages/grapher/package.json
+++ b/packages/grapher/package.json
@@ -6,10 +6,13 @@
     "type": "git",
     "url": "https://github.com/microsoft/workspace-tools"
   },
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "bin": {
+    "grapher": "./bin/grapher.js"
+  },
+  "exports": null,
   "files": [
-    "lib/!(__*)"
+    "lib/!(__*)",
+    "lib/!(__*)/**/*"
   ],
   "scripts": {
     "build": "tsc",
@@ -18,7 +21,7 @@
   },
   "dependencies": {
     "commander": "^10.0.1",
-    "workspace-tools": "^0.34.2"
+    "workspace-tools": "^0.34.3"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",

--- a/packages/grapher/src/index.ts
+++ b/packages/grapher/src/index.ts
@@ -4,7 +4,7 @@ import { depsCommand } from "./commands/depsCommand";
 async function main() {
   try {
     const program = new commander.Command();
-    program.version("0.0.1");
+    program.version(require("../package.json").version);
     program
       .command("deps")
       .description("Generate a list of dependencies and dependents for a package")
@@ -14,7 +14,7 @@ async function main() {
     program.parse(process.argv);
   } catch (e) {
     if (e instanceof Error) {
-      console.error(e.message);
+      console.error(e.stack);
     } else {
       console.error(String(e));
     }

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-tools",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/!(__*)"
+    "lib/!(__*)",
+    "lib/!(__*)/**/*"
   ],
   "scripts": {
     "api": "workspace-tools-scripts api",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,41 +1471,41 @@ git-url-parse@^13.0.0:
   dependencies:
     git-up "^7.0.0"
 
-glob-hasher-darwin-arm64@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/glob-hasher-darwin-arm64/-/glob-hasher-darwin-arm64-1.2.1.tgz#642de0fc1f8fc92c3d6b5dd54bf0a95c219ff188"
-  integrity sha512-zm9bcLTmrN4WrLn60T6PVs3s3Wp4ebp8nAdtenF5UZ7mWo1V/d/BSVGbp/4HNXZz8oH8FoNNRDfA4irj7O7sYg==
+glob-hasher-darwin-arm64@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/glob-hasher-darwin-arm64/-/glob-hasher-darwin-arm64-1.3.0.tgz#98dd31a7b08c3c9940a99ea391af405778065d79"
+  integrity sha512-xJk+chXLeVBamYQ2fo1Plk0uqoUkv42o7PYZBVr7lSy9eoBAqXKCcf23godpA1BoUfz2cWpvzhI0Nl+MQsJX6g==
 
-glob-hasher-darwin-x64@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/glob-hasher-darwin-x64/-/glob-hasher-darwin-x64-1.2.1.tgz#85fff7adede9a7b51fec6ebbcbdc01e399dbf4b0"
-  integrity sha512-5/ywPOZaMWHuk6L8SDd5Ndi0cAZTbbrYyTyZsjGAiY7Lo7qsAxtMV5DY19+z1NlO2vhTKbRVnqdS/r7vlhjvjQ==
+glob-hasher-darwin-x64@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/glob-hasher-darwin-x64/-/glob-hasher-darwin-x64-1.3.0.tgz#dd0f3723f41e69dd851de3be145f8c1e132b8ea9"
+  integrity sha512-RpXjO136MYGi+GyQgYgDqsBmyrLUhSJTwsEZx8mhF/3JcH5/RW/RVhr9PSB9Mt/FU1MH099Ln03G+u3OEDK46g==
 
-glob-hasher-linux-x64-gnu@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/glob-hasher-linux-x64-gnu/-/glob-hasher-linux-x64-gnu-1.2.1.tgz#3ce5ee596f2610843865edf9290c48230b8059f2"
-  integrity sha512-QBuGYH1av9rPaOKHid0EWwruuEhEaI9T04oM66Q7LpJVFdkmSVaBj/8GJgBnA4UjraBpr7PMM5+5nvxZ/a8u4Q==
+glob-hasher-linux-x64-gnu@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/glob-hasher-linux-x64-gnu/-/glob-hasher-linux-x64-gnu-1.3.0.tgz#cc3b94deb935f92aee980507daec3d4eef12a0f1"
+  integrity sha512-B8woNLpg+JEdyD9Lfqvmm0rWDn2aYrh04SthIw2i1hdXwBm53JgsNIcdMnkhW9ZZtRI8LH5uTcQgPmC46lCE4w==
 
-glob-hasher-win32-arm64-msvc@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/glob-hasher-win32-arm64-msvc/-/glob-hasher-win32-arm64-msvc-1.2.1.tgz#a40ba3676e914e9f6e28c1b1ac557fa09191221d"
-  integrity sha512-8ISCz8cpA33yt5TH3DMEVTsZBxozpHuDAg7JOf8zlXElEvLJ6TLkdJyubvG/VRmIzd4S0qtUeLNl9fDh5LHM7Q==
+glob-hasher-win32-arm64-msvc@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/glob-hasher-win32-arm64-msvc/-/glob-hasher-win32-arm64-msvc-1.3.0.tgz#eff90a37fb7a8372ce2d12315ee154341fecd7a9"
+  integrity sha512-mndlrg8lgXoHjzZooHh5aBkS5vOKRzVYBQkNKhqXmeSK6uV4VPnDYE3I/G7ucyNJc1CcAjQ9YTktwXNJkshLVg==
 
-glob-hasher-win32-x64-msvc@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/glob-hasher-win32-x64-msvc/-/glob-hasher-win32-x64-msvc-1.2.1.tgz#99c66196f330c9da4f054f405283727bb8715cf0"
-  integrity sha512-sM+7R9/gmhAQ/TjndTqsOLPjCmmxN5jhY42ROvlOoRMgY76dsUn7Hshm1U1ctE/n+4nPEUTD4eEpVERCDaV55A==
+glob-hasher-win32-x64-msvc@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/glob-hasher-win32-x64-msvc/-/glob-hasher-win32-x64-msvc-1.3.0.tgz#fa862a1c857cf3f5736fcc4c247d69fcf0e444b5"
+  integrity sha512-Gs4y0ZX4bJzLA2F9zAafvUJEZEEYYEDREEhdec3KB+a3pPxxjlVtNgH0hVOgXfzv8WRqUdFIff7a1vyem+y2NQ==
 
-glob-hasher@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/glob-hasher/-/glob-hasher-1.2.1.tgz#7b2fd2e11f9053cc4a53f3de6ea934c8ad4d83e4"
-  integrity sha512-Z2d2NN/CYaoJf2Sbsee2thKO2yzc8HfSawFtdJqh9LbvZETRCBquwyAVUFpBSd1g84KUd7rkWI6kFrQt3CmNSg==
+glob-hasher@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/glob-hasher/-/glob-hasher-1.3.0.tgz#f43cc931bd0c364b0db8d8f08ab357cf967899b7"
+  integrity sha512-kwtzRkuYcF1FfO5h7rwMtklwI2wtAXh4BreHxgSSvoFQ4XGdtIIxkXUEmmvIsCrVr2NVBSNyCmcCXxkddtUv9w==
   optionalDependencies:
-    glob-hasher-darwin-arm64 "1.2.1"
-    glob-hasher-darwin-x64 "1.2.1"
-    glob-hasher-linux-x64-gnu "1.2.1"
-    glob-hasher-win32-arm64-msvc "1.2.1"
-    glob-hasher-win32-x64-msvc "1.2.1"
+    glob-hasher-darwin-arm64 "1.3.0"
+    glob-hasher-darwin-x64 "1.3.0"
+    glob-hasher-linux-x64-gnu "1.3.0"
+    glob-hasher-win32-arm64-msvc "1.3.0"
+    glob-hasher-win32-x64-msvc "1.3.0"
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -2160,12 +2160,12 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lage@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-2.5.2.tgz#07df8b7d6357314ace3a151d8a9b1311c64ea97c"
-  integrity sha512-dYlkErh6LQ5zabLvsK5P72HO3FpwqEHoFfvtWW+KT90xYtMX+bFY8t+Auc23DgQ8s+WHRhXyZigmAqcHEQBP1g==
+lage@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-2.6.2.tgz#0d1710d528a2a2af94b991afbb7048668a958815"
+  integrity sha512-P5Sc6zyjuqGoxN1F0GwEFEbfxfuR0A93oYTqAdZTXGUWwbIWi82DJcTr8DIrN/iapq7eBjXVtxWwoIak1iFD7Q==
   dependencies:
-    glob-hasher "1.2.1"
+    glob-hasher "^1.3.0"
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -2876,10 +2876,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-workspace-tools@^0.30.0, "workspace-tools@npm:workspace-tools@0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.33.0.tgz#c49f78843ab0ac0fba23a30b6dfaa47558b9ee11"
-  integrity sha512-BiaNyvqn2m9hN3tu5ccxc+yqUaG7ecWOIdWxDrv796016nhv8zE+Ch22wexES2662+HOmdqGYk698/jrdlCoCA==
+workspace-tools@^0.30.0, "workspace-tools@npm:workspace-tools@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.34.3.tgz#066a71dcf9f6a7ed9ad9f651839a1b31d7595d5e"
+  integrity sha512-DRG4tXQ8Mg+KoduEsd6Tu2zDukZiiR7Q+JxaZKUJyvrPREeG2CL3hoUtJMi7s4iVUcKZVm5uWaPmuiRTmrLVbQ==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     git-url-parse "^13.0.0"


### PR DESCRIPTION
The new `@ws-tools/grapher` package was missing a `bin`, when the implementation and readme suggests it was intended to be run that way.

This PR adds a `bin/grapher.js`. I also added an empty exports map (replacing main/types) to prevent importing the package, since it's intended for use as a CLI.