### PR TITLE
searchUp: handle relative cwd

### DIFF
--- a/change/change-cfde5f09-6ac1-428d-895b-8bf8fe4a905e.json
+++ b/change/change-cfde5f09-6ac1-428d-895b-8bf8fe4a905e.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "searchUp: handle relative cwd",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/src/paths.ts
+++ b/packages/workspace-tools/src/paths.ts
@@ -11,6 +11,8 @@ import { logVerboseWarning } from "./logging";
  */
 export function searchUp(filePath: string | string[], cwd: string) {
   const paths = typeof filePath === "string" ? [filePath] : filePath;
+  // convert to an absolute path if needed
+  cwd = path.resolve(cwd);
   const root = path.parse(cwd).root;
 
   let foundPath: string | undefined;


### PR DESCRIPTION
`searchUp` should convert its `cwd` to an absolute path before searching for the file. Fixes #245.