### PR TITLE
getRecentCommitMessages: filter out empty lines

### DIFF
--- a/change/change-fdad4411-5b3b-49c8-8d66-cc9f5e8d9bb7.json
+++ b/change/change-fdad4411-5b3b-49c8-8d66-cc9f5e8d9bb7.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "getRecentCommitMessages: filter out empty lines",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -94,9 +94,9 @@ export function getRecentCommitMessages(branch: string, cwd: string) {
     }
 
     return results.stdout
-      .trim()
       .split(/\n/)
-      .map((line) => line.trim());
+      .map((line) => line.trim())
+      .filter((line) => !!line);
   } catch (e) {
     throw new GitError(`Cannot gather information about recent commits`, e);
   }


### PR DESCRIPTION
Splitting an empty string returns `['']`, so we need to explicitly filter empty lines. Fixes
https://github.com/microsoft/beachball/issues/793