### PR TITLE
Go back to transpiling to ES2021

### DIFF
--- a/change/change-ae861a35-debd-48d9-a164-d63c3ac983aa.json
+++ b/change/change-ae861a35-debd-48d9-a164-d63c3ac983aa.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Go back to transpiling to ES2021",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/scripts/tsconfig.base.json
+++ b/scripts/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022"],
+    "target": "ES2021",
+    "lib": ["ES2021"],
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
Avoid immediately breaking Node 14 for the main package until beachball is upgraded.