### PR TITLE
Add postpublish step to update workspace-tools resolutions

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,4 +1,8 @@
 // @ts-check
+
+const { spawnSync } = require("child_process");
+const { getUnstagedChanges, git, stageAndCommit } = require("workspace-tools");
+
 /** @type {import('beachball').BeachballConfig} */
 const config = {
   access: "public",
@@ -6,5 +10,28 @@ const config = {
   groupChanges: true,
   scope: ["!**/__fixtures__/**"],
   ignorePatterns: ["**/jest.config.js", "**/src/__fixtures__/**", "**/src/__tests__/**"],
+  hooks: {
+    postpublish: (packagePath, name) => {
+      if (name !== "workspace-tools") {
+        return;
+      }
+
+      if (getUnstagedChanges(process.cwd()).includes("yarn.lock")) {
+        console.warn("yarn.lock unexpectedly had changes; not updating workspace-tools resolutions");
+        return;
+      }
+
+      console.log('Running "yarn --force" to update workspace-tools resolutions');
+      spawnSync("yarn", ["--force", "--ignore-scripts"], { stdio: "inherit" });
+
+      if (getUnstagedChanges(process.cwd()).includes("yarn.lock")) {
+        console.log("Committing and pushing yarn.lock changes");
+        stageAndCommit(["yarn.lock"], "Update workspace-tools resolutions", process.cwd());
+        git(["push", "--no-verify", "--verbose", "origin", "HEAD:master"]);
+      } else {
+        console.log("No changes to yarn.lock");
+      }
+    },
+  },
 };
 module.exports = config;

--- a/change/change-e5f822c1-b07e-4852-8c16-88567efc1c52.json
+++ b/change/change-e5f822c1-b07e-4852-8c16-88567efc1c52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Use trimEnd instead of trimRight",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "typescript": "~5.2.2"
   },
   "resolutions": {
-    "**/beachball/workspace-tools": "npm:workspace-tools@0.36.1",
-    "**/lage/workspace-tools": "npm:workspace-tools@0.36.1",
-    "**/lage/**/workspace-tools": "npm:workspace-tools@0.36.1"
+    "**/beachball/workspace-tools": "npm:workspace-tools@latest",
+    "**/lage/workspace-tools": "npm:workspace-tools@latest",
+    "**/lage/**/workspace-tools": "npm:workspace-tools@latest"
   }
 }

--- a/packages/workspace-tools/src/git/git.ts
+++ b/packages/workspace-tools/src/git/git.ts
@@ -69,8 +69,8 @@ export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutpu
   const output: GitProcessOutput = {
     ...results,
     // these may be undefined if stdio: inherit is set
-    stderr: (results.stderr || "").toString().trimRight(),
-    stdout: (results.stdout || "").toString().trimRight(),
+    stderr: (results.stderr || "").toString().trimEnd(),
+    stdout: (results.stdout || "").toString().trimEnd(),
     success: results.status === 0,
   };
 
@@ -103,7 +103,7 @@ export function gitFailFast(args: string[], options?: SpawnSyncOptions & { noExi
     }
 
     throw new GitError(`CRITICAL ERROR: running git command: git ${args.join(" ")}!
-    ${gitResult.stdout?.toString().trimRight()}
-    ${gitResult.stderr?.toString().trimRight()}`);
+    ${gitResult.stdout?.toString().trimEnd()}
+    ${gitResult.stderr?.toString().trimEnd()}`);
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -42,19 +42,6 @@
 
   "semanticCommits": "disabled",
 
-  "regexManagers": [
-    {
-      // This updates the "resolutions" entry for lage's workspace-tools version
-      "fileMatch": ["^package.json$"],
-      "matchStrings": [
-        "(?<depName>\\*\\*/.*?workspace-tools)\": \"npm:workspace-tools@(?<currentValue>[~^]?\\d+\\.\\d+\\.\\d+)"
-      ],
-      "packageNameTemplate": "workspace-tools",
-      "datasourceTemplate": "npm",
-      "depTypeTemplate": "devDependencies"
-    }
-  ],
-
   "packageRules": [
     {
       "groupName": "workspace-tools resolutions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,7 +2886,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-workspace-tools@^0.35.0, "workspace-tools@npm:workspace-tools@0.36.1":
+workspace-tools@^0.35.0, "workspace-tools@npm:workspace-tools@latest":
   version "0.36.1"
   resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.36.1.tgz#d40aba09312b9c60b11ce3784c64adcc87fc6fe3"
   integrity sha512-cpg+uIoQ2BCmpo9DXlGJeJF4XvrKXbNhQRJkuwe+KJJ/ZOM4pa195wMgkA1eBv9L987GS4f2SRO9WaOAIRdV8Q==


### PR DESCRIPTION
Change the `workspace-tools` resolutions to use `latest` instead of a specific version, and add a beachball `postpublish` hook to handle the update instead of using Renovate PRs which must be merged manually.