### PR TITLE
Try different approach to updating resolutions

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -2,7 +2,6 @@
 
 const { spawnSync } = require("child_process");
 const fs = require("fs");
-const { getUnstagedChanges } = require("workspace-tools");
 
 /** @type {import('beachball').BeachballConfig} */
 const config = {
@@ -16,6 +15,9 @@ const config = {
       if (name !== "workspace-tools") {
         return;
       }
+
+      // This has to be loaded here because the package won't be built yet during checkchange in CI
+      const { getUnstagedChanges } = require("workspace-tools");
 
       if (getUnstagedChanges(process.cwd()).includes("yarn.lock")) {
         console.warn("yarn.lock unexpectedly had changes; not updating workspace-tools resolutions");

--- a/change/change-27c50d82-1809-467f-8f63-2a2dabe9ba36.json
+++ b/change/change-27c50d82-1809-467f-8f63-2a2dabe9ba36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update readme",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/README.md
+++ b/packages/workspace-tools/README.md
@@ -1,6 +1,6 @@
 # workspace-tools
 
-A collection of tools that are useful in a git-controlled monorepo that is managed by one of these tools:
+A collection of utilities that are useful in a git-controlled monorepo managed by one of these tools:
 
 - lerna
 - npm workspaces
@@ -8,7 +8,7 @@ A collection of tools that are useful in a git-controlled monorepo that is manag
 - rush
 - yarn workspaces
 
-## Environment Variables
+## Environment variables
 
 ### GIT_DEBUG
 


### PR DESCRIPTION
Update workspace-tools resolutions in a `postbump` hook. Turns out just running `yarn --force` doesn't force re-resolution of tags like `latest`, so it's necessary to manually delete the old yarn.lock entry and then run `yarn`. Also, do this during postbump so the changes are committed automatically.