### PR TITLE
Remove beachball workspace-tools resolutions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,13 +15,23 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
+
       - run: yarn --frozen-lockfile
-      - run: yarn checkchange
+
       - run: yarn format:check
+
       - run: yarn build
+
+      # checkchange must come after build in case beachball ends up using the local workspace-tools
+      # (this will happen when beachball depends on a workspace-tools version which is compatible
+      # with the local version)
+      - run: yarn checkchange
+
       - run: yarn build:docs
+
       - run: yarn test

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-const { spawnSync } = require("child_process");
-const fs = require("fs");
-
 /** @type {import('beachball').BeachballConfig} */
 const config = {
   access: "public",
@@ -10,33 +7,5 @@ const config = {
   groupChanges: true,
   scope: ["!**/__fixtures__/**"],
   ignorePatterns: ["**/jest.config.js", "**/src/__fixtures__/**", "**/src/__tests__/**"],
-  hooks: {
-    postbump: (packagePath, name) => {
-      if (name !== "workspace-tools") {
-        return;
-      }
-
-      // This has to be loaded here because the package won't be built yet during checkchange in CI
-      const { getUnstagedChanges } = require("workspace-tools");
-
-      if (getUnstagedChanges(process.cwd()).includes("yarn.lock")) {
-        console.warn("yarn.lock unexpectedly had changes; not updating workspace-tools resolutions");
-        return;
-      }
-
-      let yarnLock = fs.readFileSync("yarn.lock", "utf-8");
-      const wsToolsMatch = yarnLock.match(/.*workspace-tools@npm:workspace-tools@latest[\s\S]+?\n\n/);
-      if (wsToolsMatch) {
-        console.log("Removing workspace-tools entry from yarn.lock");
-        yarnLock = yarnLock.replace(wsToolsMatch[0], "");
-        fs.writeFileSync("yarn.lock", yarnLock);
-
-        console.log("Running yarn to update workspace-tools resolutions");
-        spawnSync("yarn", ["--ignore-scripts"], { stdio: "inherit" });
-      } else {
-        console.warn("Didn't find a yarn.lock entry for workspace-tools resolutions in expected format");
-      }
-    },
-  },
 };
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -47,10 +47,5 @@
     "ts-jest": "^29.1.0",
     "typedoc": "^0.25.2",
     "typescript": "~5.2.2"
-  },
-  "resolutions": {
-    "**/beachball/workspace-tools": "npm:workspace-tools@latest",
-    "**/lage/workspace-tools": "npm:workspace-tools@latest",
-    "**/lage/**/workspace-tools": "npm:workspace-tools@latest"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,10 +2886,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-workspace-tools@^0.35.0, "workspace-tools@npm:workspace-tools@latest":
-  version "0.36.3"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.36.3.tgz#6921fb92ec4366c7016fa2052ab4dad3d1aa90b7"
-  integrity sha512-9kx+l+1ClwFbp5CM+3jwNYDFI2sHl0T1oA7ld/LKMnDcMm3225p6UjFUuXo7yMjBWCc2Yecat+0vqTHmdrzYlA==
+workspace-tools@^0.35.0:
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.35.3.tgz#a1ba3c68a997e7f1556485076d89fa95bc26e533"
+  integrity sha512-klwv7VAsrxW+d/CMBIG4B5GbpYBnJiPFy6QTiv8VBEFAM8EBUaVh2MjtHmB8nY5SnW1JzEMnSqjS4i+fVQAcXQ==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     fast-glob "^3.3.1"


### PR DESCRIPTION
Get rid of the resolutions for `beachball/workspace-tools`, and the ones for lage which are no longer needed now that lage is bundled.

The reason for adding those was because if the local version of `workspace-tools` matches the version requested by a dep, yarn will link the local `workspace-tools` instead of installing it from npm. This can create problems if we haven't built locally yet.

There are a couple downsides of using resolutions to work around this:
- It requires an extra step to upgrade every time `workspace-tools` is published. (I recently tried doing this in a beachball postbump task, which is better than renovate PRs, but still not great.)
- If the local and requested versions match, it will **only** install the version from npm instead of linking the local package. This is not a huge issue now but might start creating issues once we split the packages.

An alternative workaround now that lage is bundled (so we can build without any deps that directly use workspace-tools) is to move the `yarn checkchange` step *after* the build. This is slightly not ideal, but the workspace-tools build is fast enough that it doesn't really matter.