### PR TITLE
Support case-insensitive package name match

### DIFF
--- a/change/change-9897def3-d7e1-4148-b3c9-99486a0ac129.json
+++ b/change/change-9897def3-d7e1-4148-b3c9-99486a0ac129.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "type": "minor",
+      "type": "patch",
       "comment": "Support case-insensitive package name match",
       "packageName": "workspace-tools",
       "email": "stchur@microsoft.com",

--- a/change/change-d02bf19f-b4c1-4a33-87d1-9a9e408e534a.json
+++ b/change/change-d02bf19f-b4c1-4a33-87d1-9a9e408e534a.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Support case-insensitive package name match",
+      "packageName": "workspace-tools",
+      "email": "stchur@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/src/__tests__/getScopedPackages.test.ts
+++ b/packages/workspace-tools/src/__tests__/getScopedPackages.test.ts
@@ -38,6 +38,35 @@ describe("getScopedPackages", () => {
     expect(results).not.toContain("baz");
   });
 
+  it("matches the correct packages when search pattern starts with @, irrespective of case", () => {
+    const results = getScopedPackages(
+      ["@i-love/theavettbrothers"],
+      [
+        "@i-love/theavettbrothers",
+        "@i-love/THEAVETTBROTHERS",
+        "@i-love/TheAvettBrothers",
+        "theAvettBrothers",
+        "@i-love/JimmyEatWorld",
+      ]
+    );
+    expect(results).toContain("@i-love/theavettbrothers");
+    expect(results).toContain("@i-love/THEAVETTBROTHERS");
+    expect(results).toContain("@i-love/TheAvettBrothers");
+    expect(results).not.toContain("theAvettBrothers");
+    expect(results).not.toContain("@i-love/JimmyEatWorld");
+  });
+
+  it("matches the correct package, irrespective of case", () => {
+    const results = getScopedPackages(
+      ["ilovetheavettbrothers"],
+      ["ilovetheavettbrothers", "ILOVETHEAVETTBROTHERS", "iLoveTheAvettBrothers", "IDoNotLoveTaylorSwift"]
+    );
+    expect(results).toContain("ilovetheavettbrothers");
+    expect(results).toContain("ILOVETHEAVETTBROTHERS");
+    expect(results).toContain("iLoveTheAvettBrothers");
+    expect(results).not.toContain("IDoNotLoveTaylorSwift");
+  });
+
   it("can match with npm package scopes", () => {
     const results = getScopedPackages(["foo"], ["@yay/foo", "@yay1/foo", "foo", "baz"]);
     expect(results).toContain("@yay/foo");
@@ -83,3 +112,5 @@ describe("getScopedPackages", () => {
     expect(results).not.toContain("baz");
   });
 });
+
+// cspell:ignore ilovetheavettbrothers, theavettbrothers

--- a/packages/workspace-tools/src/scope.ts
+++ b/packages/workspace-tools/src/scope.ts
@@ -12,7 +12,7 @@ export function getScopedPackages(search: string[], packages: { [pkg: string]: u
   // perform a package-scoped search (e.g. search is @scope/foo*)
   const scopedSearch = search.filter((needle) => needle.startsWith("@") || needle.startsWith("!@"));
   if (scopedSearch.length > 0) {
-    const matched = micromatch(packageNames, scopedSearch);
+    const matched = micromatch(packageNames, scopedSearch, { nocase: true });
     for (const pkg of matched) {
       results.add(pkg);
     }
@@ -24,7 +24,7 @@ export function getScopedPackages(search: string[], packages: { [pkg: string]: u
     // only generate the bare package map if there ARE unscoped searches
     const barePackageMap = generateBarePackageMap(packageNames);
 
-    let matched = micromatch(Object.keys(barePackageMap), unscopedSearch);
+    let matched = micromatch(Object.keys(barePackageMap), unscopedSearch, { nocase: true });
     for (const bare of matched) {
       for (const pkg of barePackageMap[bare]) {
         results.add(pkg);


### PR DESCRIPTION
Adds support to lage to match package names in a case-insensitive manner, so you can have a package like:
```json
{ 
   name: "ILoveTheAvettBrothers"
   ...
}
```

And issue a command to lage, like: `large start --to ilovetheavettbrothers`

And it will still work!