### PR TITLE
Adding optional dependency filtering

### DIFF
--- a/change/change-248e2a4e-16f5-4747-93f8-edf4459ca60c.json
+++ b/change/change-248e2a4e-16f5-4747-93f8-edf4459ca60c.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "adding optional dependency filtering",
+      "packageName": "workspace-tools",
+      "email": "nemanjatesic@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -329,6 +329,8 @@ interface PackageDependenciesOptions {
     // (undocumented)
     withDevDependencies?: boolean;
     // (undocumented)
+    withOptionalDependencies?: boolean;
+    // (undocumented)
     withPeerDependencies?: boolean;
 }
 
@@ -378,6 +380,10 @@ export interface PackageInfo {
     group?: string;
     // (undocumented)
     name: string;
+    // (undocumented)
+    optionalDependencies?: {
+        [dep: string]: string;
+    };
     // (undocumented)
     packageJsonPath: string;
     // (undocumented)

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -361,6 +361,8 @@ export interface PackageGraphFilter {
     // (undocumented)
     withDevDependencies?: boolean;
     // (undocumented)
+    withOptionalDependencies?: boolean;
+    // (undocumented)
     withPeerDependencies?: boolean;
 }
 

--- a/packages/workspace-tools/src/graph/getPackageDependencies.ts
+++ b/packages/workspace-tools/src/graph/getPackageDependencies.ts
@@ -3,11 +3,12 @@ import { PackageInfo } from "../types/PackageInfo";
 export interface PackageDependenciesOptions {
   withDevDependencies?: boolean;
   withPeerDependencies?: boolean;
+  withOptionalDependencies?: boolean;
 }
 
 function isValidDependency(info: PackageInfo, dep: string): boolean {
   // check if the dependency range is specified by an external package like npm: or file:
-  const range = info.dependencies?.[dep] || info.devDependencies?.[dep] || info.peerDependencies?.[dep];
+  const range = info.dependencies?.[dep] || info.devDependencies?.[dep] || info.peerDependencies?.[dep] || info.optionalDependencies?.[dep];
 
   // this case should not happen by this point, but we will handle it anyway
   if (!range) {
@@ -42,6 +43,14 @@ export function getPackageDependencies(
 
   if (info.peerDependencies && options.withPeerDependencies) {
     for (const dep of Object.keys(info.peerDependencies)) {
+      if (dep !== info.name && packages.has(dep)) {
+        deps.push(dep);
+      }
+    }
+  }
+
+  if (info.optionalDependencies && options.withOptionalDependencies) {
+    for (const dep of Object.keys(info.optionalDependencies)) {
       if (dep !== info.name && packages.has(dep)) {
         deps.push(dep);
       }

--- a/packages/workspace-tools/src/graph/getPackageDependencies.ts
+++ b/packages/workspace-tools/src/graph/getPackageDependencies.ts
@@ -8,7 +8,11 @@ export interface PackageDependenciesOptions {
 
 function isValidDependency(info: PackageInfo, dep: string): boolean {
   // check if the dependency range is specified by an external package like npm: or file:
-  const range = info.dependencies?.[dep] || info.devDependencies?.[dep] || info.peerDependencies?.[dep] || info.optionalDependencies?.[dep];
+  const range =
+    info.dependencies?.[dep] ||
+    info.devDependencies?.[dep] ||
+    info.peerDependencies?.[dep] ||
+    info.optionalDependencies?.[dep];
 
   // this case should not happen by this point, but we will handle it anyway
   if (!range) {

--- a/packages/workspace-tools/src/types/PackageInfo.ts
+++ b/packages/workspace-tools/src/types/PackageInfo.ts
@@ -5,6 +5,7 @@ export interface PackageInfo {
   dependencies?: { [dep: string]: string };
   devDependencies?: { [dep: string]: string };
   peerDependencies?: { [dep: string]: string };
+  optionalDependencies?: { [dep: string]: string };
   private?: boolean;
   group?: string;
   scripts?: { [scriptName: string]: string };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,6 +2878,19 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+workspace-tools@^0.36.3:
+  version "0.36.4"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.36.4.tgz#57504c687569785148c5b7ef1470dadc9be970c5"
+  integrity sha512-v0UFVvw9BjHtRu2Dau5PEJKkuG8u4jPlpXZQWjSz9XgbSutpPURqtO2P0hp3cVmQVATh8lkMFCewFgJuDnyC/w==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    fast-glob "^3.3.1"
+    git-url-parse "^13.0.0"
+    globby "^11.0.0"
+    jju "^1.4.0"
+    js-yaml "^4.1.0"
+    micromatch "^4.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,19 +2878,6 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-workspace-tools@^0.36.3:
-  version "0.36.4"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.36.4.tgz#57504c687569785148c5b7ef1470dadc9be970c5"
-  integrity sha512-v0UFVvw9BjHtRu2Dau5PEJKkuG8u4jPlpXZQWjSz9XgbSutpPURqtO2P0hp3cVmQVATh8lkMFCewFgJuDnyC/w==
-  dependencies:
-    "@yarnpkg/lockfile" "^1.1.0"
-    fast-glob "^3.3.1"
-    git-url-parse "^13.0.0"
-    globby "^11.0.0"
-    jju "^1.4.0"
-    js-yaml "^4.1.0"
-    micromatch "^4.0.0"
-
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"


### PR DESCRIPTION
This pull request introduces the capability to handle optional dependencies in the `workspace-tools` package. The main changes include adding support for optional dependencies in various interfaces, updating the package graph creation logic, and enhancing the test suite to cover these new scenarios.

### Support for Optional Dependencies:

* [`packages/workspace-tools/etc/workspace-tools.api.md`](diffhunk://#diff-b7db85e44f265f65ea4edc79ced987c74f9a7712584a17f0dfff8aef7dabd31fR332-R333): Added `withOptionalDependencies` to `PackageDependenciesOptions` and `PackageGraphFilter` interfaces, and included `optionalDependencies` in the `PackageInfo` interface. [[1]](diffhunk://#diff-b7db85e44f265f65ea4edc79ced987c74f9a7712584a17f0dfff8aef7dabd31fR332-R333) [[2]](diffhunk://#diff-b7db85e44f265f65ea4edc79ced987c74f9a7712584a17f0dfff8aef7dabd31fR364-R365) [[3]](diffhunk://#diff-b7db85e44f265f65ea4edc79ced987c74f9a7712584a17f0dfff8aef7dabd31fR386-R389)
* [`packages/workspace-tools/src/types/PackageInfo.ts`](diffhunk://#diff-420b967289af77b17d7daaa5a0ca1c23849b834a4884be5e6aa868cee71119b9R8): Included `optionalDependencies` in the `PackageInfo` interface.

### Package Graph Creation:

* [`packages/workspace-tools/src/graph/createPackageGraph.ts`](diffhunk://#diff-d6eb1a2fa1df596473566dc24bc6b6f209817c8900fbd0886133521aca0085e8R15): Modified the `createPackageGraph` function to support filtering with optional dependencies and optimized the dependency map caching logic. [[1]](diffhunk://#diff-d6eb1a2fa1df596473566dc24bc6b6f209817c8900fbd0886133521aca0085e8R15) [[2]](diffhunk://#diff-d6eb1a2fa1df596473566dc24bc6b6f209817c8900fbd0886133521aca0085e8L26-R34) [[3]](diffhunk://#diff-d6eb1a2fa1df596473566dc24bc6b6f209817c8900fbd0886133521aca0085e8L88-R113)

### Dependency Retrieval:

* [`packages/workspace-tools/src/graph/getPackageDependencies.ts`](diffhunk://#diff-9e484bf8155019267bd5de40acfe9734f19d7f8c50c637e765d0f9da6000c2ceR6-R15): Updated the `getPackageDependencies` function to include optional dependencies when specified in the options. [[1]](diffhunk://#diff-9e484bf8155019267bd5de40acfe9734f19d7f8c50c637e765d0f9da6000c2ceR6-R15) [[2]](diffhunk://#diff-9e484bf8155019267bd5de40acfe9734f19d7f8c50c637e765d0f9da6000c2ceR56-R63)

### Test Enhancements:

* [`packages/workspace-tools/src/__tests__/graph.test.ts`](diffhunk://#diff-35d2ecca085997c9a10fc6e261f974c66a7bbbec14bf4e23007d2f0b87a15974R41-R70): Added tests for scenarios involving optional dependencies in both `getPackageDependencies` and `createPackageGraph` functions. [[1]](diffhunk://#diff-35d2ecca085997c9a10fc6e261f974c66a7bbbec14bf4e23007d2f0b87a15974R41-R70) [[2]](diffhunk://#diff-35d2ecca085997c9a10fc6e261f974c66a7bbbec14bf4e23007d2f0b87a15974R442-R532) [[3]](diffhunk://#diff-35d2ecca085997c9a10fc6e261f974c66a7bbbec14bf4e23007d2f0b87a15974R541-R544)

### Change Documentation:

* [`change/change-248e2a4e-16f5-4747-93f8-edf4459ca60c.json`](diffhunk://#diff-788ea06adb63fef21951a65dcd80aed20bb296e4b348911f68a795af3810b363R1-R11): Documented the addition of optional dependency filtering as a minor change.