### PR TITLE
gitUtilities: processGitOutput should throw if git failed

### DIFF
--- a/change/change-9b9ee9b0-a703-470b-9f68-3d61e98f1540.json
+++ b/change/change-9b9ee9b0-a703-470b-9f68-3d61e98f1540.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "processGitOutput should throw when stderr is defined",
+      "packageName": "workspace-tools",
+      "email": "email not defined",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -286,11 +286,10 @@ export function listAllTrackedFiles(patterns: string[], cwd: string) {
 }
 
 function processGitOutput(output: GitProcessOutput) {
-  if (output.stderr) {
-    throw new Error(output.stderr);
-  }
-
   if (!output.success) {
+    if (output.stderr) {
+      throw new Error(output.stderr);
+    }
     return [];
   }
 

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -289,7 +289,7 @@ function processGitOutput(output: GitProcessOutput) {
   if (output.stderr) {
     throw new Error(output.stderr);
   }
-  
+
   if (!output.success) {
     return [];
   }

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -286,6 +286,10 @@ export function listAllTrackedFiles(patterns: string[], cwd: string) {
 }
 
 function processGitOutput(output: GitProcessOutput) {
+  if (output.stderr) {
+    throw new Error(output.stderr);
+  }
+  
   if (!output.success) {
     return [];
   }

--- a/scripts/jest/setupFixture.ts
+++ b/scripts/jest/setupFixture.ts
@@ -84,6 +84,7 @@ export function setupLocalRemote(cwd: string, remoteName: string, fixtureName?: 
   const remoteCwd = setupFixture(fixtureName);
   const remoteUrl = remoteCwd.replace(/\\/g, "/");
   basicGit(["remote", "add", remoteName, remoteUrl], { cwd });
+  basicGit(["config", "pull.rebase", "false"], { cwd });
   basicGit(["pull", "-X", "ours", "origin", "main", "--allow-unrelated-histories"], { cwd });
   // Configure url in package.json
   setupPackageJson(cwd, { repository: { url: remoteUrl, type: "git" } });

--- a/scripts/jest/setupFixture.ts
+++ b/scripts/jest/setupFixture.ts
@@ -80,10 +80,11 @@ export function setupPackageJson(cwd: string, packageJson: Record<string, any> =
 }
 
 export function setupLocalRemote(cwd: string, remoteName: string, fixtureName?: string) {
-  // Create a seperate repo and configure it as a remote
+  // Create a separate repo and configure it as a remote
   const remoteCwd = setupFixture(fixtureName);
   const remoteUrl = remoteCwd.replace(/\\/g, "/");
   basicGit(["remote", "add", remoteName, remoteUrl], { cwd });
+  basicGit(["pull", "-X", "ours", "origin", "main", "--allow-unrelated-histories"], { cwd });
   // Configure url in package.json
   setupPackageJson(cwd, { repository: { url: remoteUrl, type: "git" } });
 }


### PR DESCRIPTION
**Bug explanation:**

Affected functions from gitUtilities:

1. getUntrackedChanges
2. getUnstagedChanges
3. getChanges
4. getBranchChanges
5. getStagedChanges

All these functions expect to catch and re-throw git exceptions with extra details, but internal processGitOutput function does not consider stderr at all and in such way it swallows git errors. 

**Bug repro:**
This repro is for one particular example when we want to make sure that git command will throw. We use the fact that git diff ${fromRef}...${toRef} (3 dots!) command which is used in getBranchChanges relies on the common ancestor to compare changes. So let's use shallow git clone to make that possible.
1.  git clone some your repo with git clone <repo> --depth 1
2.  git fetch origin <some old branch>
3. call getBranchChanges()
4. Expected behavior: function will throw error which contains git error message: " fatal: origin/main...HEAD: no merge base"
5. Actual behavior: function returns empty array (which indicated that there are no changes between these two branches)

**Bug fix:**

processGitOutput should throw if git failed