### PR TITLE
Limit git rev-list to one result

### DIFF
--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -150,10 +150,10 @@ export function getCurrentHash(cwd: string) {
  * Get the commit hash in which the file was first added.
  */
 export function getFileAddedHash(filename: string, cwd: string) {
-  const results = git(["rev-list", "HEAD", filename], { cwd });
+  const results = git(["rev-list", "--max-count=1", "HEAD", filename], { cwd });
 
   if (results.success) {
-    return results.stdout.trim().split("\n").slice(-1)[0];
+    return results.stdout.trim();
   }
 
   return undefined;


### PR DESCRIPTION
Currently `getFileAddedHash` gets all commits that changed the given path and then discards all but the first result. By using `--max-count=1` we can avoid getting more commits than necessary. This can lead to significant performance improvements in large repos.