### PR TITLE
Export getPackageDependencies

### DIFF
--- a/change/change-645a329a-2487-4ff5-a472-5bf9560053a1.json
+++ b/change/change-645a329a-2487-4ff5-a472-5bf9560053a1.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Export getPackageDependencies",
+      "type": "patch",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -31,8 +31,6 @@ export function clearGitObservers(): void;
 // @public (undocumented)
 export function commit(message: string, cwd: string, options?: string[]): void;
 
-// Warning: (ae-forgotten-export) The symbol "PackageDependenciesOptions" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function createDependencyMap(packages: PackageInfos, options?: PackageDependenciesOptions): DependencyMap;
 
@@ -133,13 +131,11 @@ export function getFileAddedHash(filename: string, cwd: string): string | undefi
 // @public (undocumented)
 export function getFullBranchRef(branch: string, cwd: string): string | null;
 
-// Warning: (ae-forgotten-export) The symbol "getPackageDependencies" needs to be exported by the entry point index.d.ts
-//
 // @public @deprecated (undocumented)
 export const getInternalDeps: typeof getPackageDependencies;
 
 // @public (undocumented)
-function getPackageDependencies(info: PackageInfo, packages: Set<string>, options?: PackageDependenciesOptions): string[];
+export function getPackageDependencies(info: PackageInfo, packages: Set<string>, options?: PackageDependenciesOptions): string[];
 
 // @public (undocumented)
 export function getPackageInfos(cwd: string): PackageInfos;
@@ -325,7 +321,7 @@ export interface NpmWorkspacesInfo {
 }
 
 // @public (undocumented)
-interface PackageDependenciesOptions {
+export interface PackageDependenciesOptions {
     // (undocumented)
     withDevDependencies?: boolean;
     // (undocumented)

--- a/packages/workspace-tools/src/graph/index.ts
+++ b/packages/workspace-tools/src/graph/index.ts
@@ -1,5 +1,6 @@
 export * from "./createPackageGraph";
 export * from "./createDependencyMap";
+export * from "./getPackageDependencies";
 import { PackageInfos } from "../types/PackageInfo";
 import { createDependencyMap } from "./createDependencyMap";
 


### PR DESCRIPTION
This is being used by beachball via a deep import, which isn't great. Export it directly instead.