### PR TITLE
Update git URL parsing logic

### DIFF
--- a/change/change-514a6ef5-c548-4a53-a7e9-98b6b136d475.json
+++ b/change/change-514a6ef5-c548-4a53-a7e9-98b6b136d475.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update `git-url-parse` to v16, modify `getRepositoryName` URL checks, and always set `shell: false` in `git()`. There's a slight chance this could change behavior for less-common URL formats.",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-9d24983f-f1a5-481b-94c2-4dd5b1678bad.json
+++ b/change/change-9d24983f-f1a5-481b-94c2-4dd5b1678bad.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "patch",
-      "comment": "Update `git-url-parse` to v16, and modify `getRepositoryName` URL checks. There's a slight chance this could change behavior for less-common URL formats.",
+      "comment": "Update `git()` to always set `shell: false` and validate that the `--upload-pack` option is not provided",
       "packageName": "workspace-tools",
       "email": "elcraig@microsoft.com",
       "dependentChangeType": "patch"

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
     "fast-glob": "^3.3.1",
-    "git-url-parse": "^13.0.0",
+    "git-url-parse": "^16.0.0",
     "globby": "^11.0.0",
     "jju": "^1.4.0",
     "js-yaml": "^4.1.0",

--- a/packages/workspace-tools/src/git/getRepositoryName.ts
+++ b/packages/workspace-tools/src/git/getRepositoryName.ts
@@ -21,11 +21,12 @@ export function getRepositoryName(url: string) {
     // https://dev.azure.com/foo/bar/_git/_optimized/some-repo
     // https://user@dev.azure.com/foo/bar/_git/some-repo
     // git@ssh.dev.azure.com:v3/foo/bar/some-repo
-    let fixedUrl = url.replace("/_optimized/", "/").replace("/DefaultCollection/", "/");
-    const parsedUrl = gitUrlParse(fixedUrl);
+    const parsedUrl = gitUrlParse(url.replace("/_optimized/", "/").replace("/DefaultCollection/", "/"));
 
-    const isVSO = fixedUrl.includes(".visualstudio.com");
-    const isADO = fixedUrl.includes("dev.azure.com");
+    // `host` is set in `parse-url` but not documented... https://github.com/IonicaBizau/parse-url/blob/c830d48647f33c054745a916cf7c4c58722f4b25/src/index.js#L28
+    const host: string = (parsedUrl as any).host || "";
+    const isVSO = host.endsWith(".visualstudio.com");
+    const isADO = host.endsWith("dev.azure.com");
     if (!isVSO && !isADO) {
       return parsedUrl.full_name;
     }
@@ -43,7 +44,7 @@ export function getRepositoryName(url: string) {
     let organization: string | undefined = parsedUrl.organization;
     if (!organization && isVSO) {
       // organization is missing or wrong for VSO
-      organization = parsedUrl.resource.match(/([^.@]+)\.visualstudio\.com/)?.[1];
+      organization = host.match(/([^.@]+)\.visualstudio\.com$/)?.[1];
     }
     return `${organization}/${parsedUrl.owner}/${parsedUrl.name}`;
   } catch (err) {

--- a/packages/workspace-tools/src/git/getRepositoryName.ts
+++ b/packages/workspace-tools/src/git/getRepositoryName.ts
@@ -26,8 +26,7 @@ export function getRepositoryName(url: string) {
     // `host` is set in `parse-url` but not documented... https://github.com/IonicaBizau/parse-url/blob/c830d48647f33c054745a916cf7c4c58722f4b25/src/index.js#L28
     const host: string = (parsedUrl as any).host || "";
     const isVSO = host.endsWith(".visualstudio.com");
-    const isADO = host.endsWith("dev.azure.com");
-    if (!isVSO && !isADO) {
+    if (!isVSO && host !== "dev.azure.com" && host !== "ssh.dev.azure.com") {
       return parsedUrl.full_name;
     }
 

--- a/packages/workspace-tools/src/git/git.ts
+++ b/packages/workspace-tools/src/git/git.ts
@@ -68,6 +68,11 @@ function removeGitObserver(observer: GitObserver) {
  */
 export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutput {
   isDebug && console.log(`git ${args.join(" ")}`);
+  if (args.some((arg) => arg.startsWith("--upload-pack"))) {
+    // This is a security issue and not needed for any expected usage of this library.
+    throw new GitError("git command contains --upload-pack, which is not allowed: " + args.join(" "));
+  }
+
   const results = spawnSync("git", args, { maxBuffer: defaultMaxBuffer, ...options, shell: false });
 
   const output: GitProcessOutput = {

--- a/packages/workspace-tools/src/git/git.ts
+++ b/packages/workspace-tools/src/git/git.ts
@@ -60,11 +60,15 @@ function removeGitObserver(observer: GitObserver) {
 }
 
 /**
- * Runs git command - use this for read-only commands
+ * Runs git command - use this for read-only commands.
+ * `gitFailFast` is recommended for commands that make changes to the filesystem.
+ *
+ * The caller is responsible for validating the input.
+ * `shell` will always be set to false.
  */
 export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutput {
   isDebug && console.log(`git ${args.join(" ")}`);
-  const results = spawnSync("git", args, { maxBuffer: defaultMaxBuffer, ...options });
+  const results = spawnSync("git", args, { maxBuffer: defaultMaxBuffer, ...options, shell: false });
 
   const output: GitProcessOutput = {
     ...results,
@@ -93,7 +97,11 @@ export function git(args: string[], options?: SpawnSyncOptions): GitProcessOutpu
 }
 
 /**
- * Runs git command - use this for commands that make changes to the filesystem
+ * Runs git command and throws an error if it fails.
+ * Use this for commands that make changes to the filesystem.
+ *
+ * The caller is responsible for validating the input.
+ * `shell` will always be set to false.
  */
 export function gitFailFast(args: string[], options?: SpawnSyncOptions & { noExitCode?: boolean }) {
   const gitResult = git(args, options);

--- a/scripts/tsconfig.base.json
+++ b/scripts/tsconfig.base.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "types": ["node", "jest"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,6 +767,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.126.tgz#27875faa2926c0f475b39a8bb1e546c0176f8d4b"
   integrity sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==
 
+"@types/parse-path@^7.0.0":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/parse-path/-/parse-path-7.0.3.tgz#cec2da2834ab58eb2eb579122d9a1fc13bd7ef36"
+  integrity sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
@@ -1380,20 +1385,20 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-git-up@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/git-up/-/git-up-7.0.0.tgz#bace30786e36f56ea341b6f69adfd83286337467"
-  integrity sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==
+git-up@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-8.1.1.tgz#06262adadb89a4a614d2922d803a0eda054be8c5"
+  integrity sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==
   dependencies:
     is-ssh "^1.4.0"
-    parse-url "^8.1.0"
+    parse-url "^9.2.0"
 
-git-url-parse@^13.0.0:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-13.1.1.tgz#664bddf0857c6a75b3c1f0ae6239abb08a1486d4"
-  integrity sha512-PCFJyeSSdtnbfhSNRw9Wk96dDCNx+sogTe4YNXeXSJxt7xz5hvXekuRn9JX7m+Mf4OscCu8h+mtAl3+h5Fo8lQ==
+git-url-parse@^16.0.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-16.1.0.tgz#3bb6f378a2ba2903c4d8b1cdec004aa85a7ab66f"
+  integrity sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==
   dependencies:
-    git-up "^7.0.0"
+    git-up "^8.1.0"
 
 glob-hasher-darwin-arm64@1.4.2:
   version "1.4.2"
@@ -2310,11 +2315,12 @@ parse-path@^7.0.0:
   dependencies:
     protocols "^2.0.0"
 
-parse-url@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-8.1.0.tgz#972e0827ed4b57fc85f0ea6b0d839f0d8a57a57d"
-  integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
+parse-url@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-9.2.0.tgz#d75da32b3bbade66e4eb0763fb4851d27526b97b"
+  integrity sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==
   dependencies:
+    "@types/parse-path" "^7.0.0"
     parse-path "^7.0.0"
 
 path-exists@^4.0.0:


### PR DESCRIPTION
Update `git-url-parse` (used by `getRepositoryName`) to v16, and anchor hostname checks in `getRepositoryName`. There's a slight chance this could change behavior for less-common URL formats, but it's not likely. 

Also update `git()` to always set `shell: false` and ban the `--upload-pack` argument (it's insecure and not needed in any expected usage). It's probably not feasible to validate all possible arguments, so further validation is up to the caller.